### PR TITLE
Simulated flows with static data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/App.js
+++ b/src/App.js
@@ -5,9 +5,11 @@ import LocationSelector from './components/LocationSelector';
 import MaterialRequestForm from './components/MaterialRequestForm';
 import PdvUpdateForm from './components/PdvUpdateForm';
 import ConfirmationMessage from './components/ConfirmationMessage';
+import PreviousRequests from './components/PreviousRequests';
+import { getStorageItem, setStorageItem } from './utils/storage';
 
 const App = () => {
-  const [currentPage, setCurrentPage] = useState('home'); // 'home', 'trade-nacional', 'trade-regional', 'channel-select', 'location-select', 'request-material', 'update-pdv', 'confirm-request', 'confirm-update'
+  const [currentPage, setCurrentPage] = useState('home'); // 'home', 'trade-nacional', 'trade-regional', 'channel-select', 'location-select', 'pdv-actions', 'request-material', 'update-pdv', 'previous-requests', 'confirm-request', 'confirm-update'
   const [selectedTradeType, setSelectedTradeType] = useState(''); // 'nacional' o 'regional'
   const [selectedChannelId, setSelectedChannelId] = useState('');
   const [selectedPdvId, setSelectedPdvId] = useState('');
@@ -36,8 +38,14 @@ const App = () => {
     setCurrentPage('update-pdv');
   };
 
+  const handleViewRequests = () => {
+    setCurrentPage('previous-requests');
+  };
+
   const handleConfirmRequest = (requestDetails) => {
     console.log('Solicitud de Material Confirmada:', requestDetails);
+    const existing = getStorageItem('material-requests') || [];
+    setStorageItem('material-requests', [...existing, requestDetails]);
     setConfirmationMessage('¡Tu solicitud de material ha sido enviada con éxito!');
     setCurrentPage('confirm-request');
   };
@@ -73,6 +81,8 @@ const App = () => {
         return 'Solicitar Material';
       case 'update-pdv':
         return 'Actualizar PDV';
+      case 'previous-requests':
+        return 'Solicitudes Anteriores';
       case 'confirm-request':
       case 'confirm-update':
         return 'Confirmación';
@@ -94,6 +104,9 @@ const App = () => {
         break;
       case 'request-material':
       case 'update-pdv':
+        setCurrentPage('pdv-actions');
+        break;
+      case 'previous-requests':
         setCurrentPage('pdv-actions');
         break;
       case 'confirm-request':
@@ -154,6 +167,12 @@ const App = () => {
               >
                 Actualizar Datos del PDV
               </button>
+              <button
+                onClick={handleViewRequests}
+                className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+              >
+                Ver Solicitudes Anteriores
+              </button>
             </div>
           </div>
         )}
@@ -166,6 +185,10 @@ const App = () => {
           <PdvUpdateForm selectedPdvId={selectedPdvId} onUpdateConfirm={handleUpdateConfirm} />
         )}
 
+        {currentPage === 'previous-requests' && (
+          <PreviousRequests pdvId={selectedPdvId} onBack={handleBack} />
+        )}
+
         {(currentPage === 'confirm-request' || currentPage === 'confirm-update') && (
           <ConfirmationMessage message={confirmationMessage} onGoHome={handleGoHome} />
         )}
@@ -175,5 +198,3 @@ const App = () => {
 };
 
 export default App;
-
-// DONE

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -6,6 +6,7 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
   const [selectedSubterritory, setSelectedSubterritory] = useState('');
   const [availableSubterritories, setAvailableSubterritories] = useState([]);
   const [availablePdvs, setAvailablePdvs] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
 
   useEffect(() => {
     if (selectedRegion) {
@@ -22,6 +23,7 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
   useEffect(() => {
     if (selectedSubterritory) {
       setAvailablePdvs(pdvs[selectedSubterritory] || []);
+      setSearchTerm('');
     } else {
       setAvailablePdvs([]);
     }
@@ -65,6 +67,15 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
 
       {selectedSubterritory && (
         <div className="mb-6">
+          <label htmlFor="pdv-search" className="block text-gray-700 text-sm font-bold mb-2">Buscar PDV:</label>
+          <input
+            type="text"
+            id="pdv-search"
+            className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all duration-200 mb-4"
+            placeholder="Ingresa nombre o código"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
           <label htmlFor="pdv-select" className="block text-gray-700 text-sm font-bold mb-2">Punto de Venta (PDV):</label>
           <select
             id="pdv-select"
@@ -72,9 +83,13 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
             onChange={(e) => onSelectPdv(e.target.value)}
           >
             <option value="">Selecciona un PDV</option>
-            {availablePdvs.map((pdv) => (
-              <option key={pdv.id} value={pdv.id}>{pdv.name}</option>
-            ))}
+            {availablePdvs
+              .filter((pdv) =>
+                pdv.name.toLowerCase().includes(searchTerm.toLowerCase())
+              )
+              .map((pdv) => (
+                <option key={pdv.id} value={pdv.id}>{pdv.name}</option>
+              ))}
           </select>
         </div>
       )}

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { getStorageItem } from '../utils/storage';
+
+const PreviousRequests = ({ pdvId, onBack }) => {
+  const requests = getStorageItem('material-requests') || [];
+  const pdvRequests = requests.filter((req) => req.pdvId === pdvId);
+
+  return (
+    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8">
+      <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Solicitudes Anteriores</h2>
+      {pdvRequests.length === 0 ? (
+        <p className="text-gray-600 text-center">No hay solicitudes previas para este PDV.</p>
+      ) : (
+        <ul className="space-y-4">
+          {pdvRequests.map((req, index) => (
+            <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
+              <p className="font-semibold text-gray-800">Solicitud #{index + 1}</p>
+              <ul className="ml-4 list-disc">
+                {req.items.map((item) => (
+                  <li key={item.id}>
+                    {item.material.name} - {item.measures.name} x {item.quantity}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        onClick={onBack}
+        className="w-full mt-6 bg-blue-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+      >
+        Volver
+      </button>
+    </div>
+  );
+};
+
+export default PreviousRequests;


### PR DESCRIPTION
## Summary
- add PreviousRequests component to show stored requests per PDV
- enable storing requests in localStorage and add button to view them
- add search box for PDV selection
- ignore `node_modules`

## Testing
- `npm test --silent --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684f7d7d7a7c8325aee125a557ac2d3e