### PR TITLE
Add previous requests history section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import LocationSelector from './components/LocationSelector';
 import MaterialRequestForm from './components/MaterialRequestForm';
 import PdvUpdateForm from './components/PdvUpdateForm';
 import ConfirmationMessage from './components/ConfirmationMessage';
+import { addRequestToHistory } from './utils/storage';
 
 const App = () => {
   const [currentPage, setCurrentPage] = useState('home'); // 'home', 'trade-nacional', 'trade-regional', 'channel-select', 'location-select', 'request-material', 'update-pdv', 'confirm-request', 'confirm-update'
@@ -38,12 +39,24 @@ const App = () => {
 
   const handleConfirmRequest = (requestDetails) => {
     console.log('Solicitud de Material Confirmada:', requestDetails);
+    addRequestToHistory(selectedChannelId, {
+      type: 'material',
+      pdvId: selectedPdvId,
+      ...requestDetails,
+      timestamp: Date.now(),
+    });
     setConfirmationMessage('¡Tu solicitud de material ha sido enviada con éxito!');
     setCurrentPage('confirm-request');
   };
 
   const handleUpdateConfirm = (updatedData) => {
     console.log('Datos del PDV Actualizados:', updatedData);
+    addRequestToHistory(selectedChannelId, {
+      type: 'pdv-update',
+      pdvId: selectedPdvId,
+      data: updatedData,
+      timestamp: Date.now(),
+    });
     setConfirmationMessage('¡Los datos del PDV han sido actualizados correctamente!');
     setCurrentPage('confirm-update');
   };

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { regions, subterritories, pdvs } from '../mock/locations';
+import PreviousRequests from './PreviousRequests';
 
 const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
   const [selectedRegion, setSelectedRegion] = useState('');
@@ -78,6 +79,9 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
           </select>
         </div>
       )}
+
+      {/* Historial de solicitudes para el canal seleccionado */}
+      <PreviousRequests channelId={selectedChannel} />
     </div>
   );
 };

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { getStorageItem } from '../utils/storage';
+
+const PreviousRequests = ({ channelId }) => {
+  const history = getStorageItem('requests-history') || {};
+  const channelHistory = history[channelId] || [];
+
+  if (channelHistory.length === 0) {
+    return (
+      <div className="mt-6">
+        <h3 className="text-xl font-semibold mb-2">Solicitudes anteriores</h3>
+        <p className="text-gray-600">No hay solicitudes registradas.</p>
+      </div>
+    );
+  }
+
+  const materialRequests = channelHistory.filter(r => r.type === 'material');
+  const pdvUpdates = channelHistory.filter(r => r.type === 'pdv-update');
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-xl font-semibold mb-2">Solicitudes anteriores</h3>
+      <div className="space-y-4">
+        {materialRequests.length > 0 && (
+          <div>
+            <h4 className="font-bold mb-1">Materiales</h4>
+            <ul className="list-disc list-inside space-y-1">
+              {materialRequests.map((req, idx) => (
+                <li key={idx} className="text-gray-700">
+                  <span className="font-medium">{req.pdvId}</span> -{' '}
+                  {new Date(req.timestamp).toLocaleDateString()} - {req.items.length} materiales
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {pdvUpdates.length > 0 && (
+          <div>
+            <h4 className="font-bold mb-1">Actualizaciones de PDV</h4>
+            <ul className="list-disc list-inside space-y-1">
+              {pdvUpdates.map((req, idx) => (
+                <li key={idx} className="text-gray-700">
+                  <span className="font-medium">{req.pdvId}</span> -{' '}
+                  {new Date(req.timestamp).toLocaleDateString()}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PreviousRequests;

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -53,3 +53,17 @@ export const removeStorageItem = (key) => {
     console.error('Error al remover de localStorage:', error);
   }
 };
+
+// Agrega una solicitud al historial agrupado por canal
+export const addRequestToHistory = (channelId, request) => {
+  try {
+    const history = getStorageItem('requests-history') || {};
+    if (!history[channelId]) {
+      history[channelId] = [];
+    }
+    history[channelId].push(request);
+    setStorageItem('requests-history', history);
+  } catch (error) {
+    console.error('Error al actualizar historial:', error);
+  }
+};


### PR DESCRIPTION
## Summary
- ignore node_modules
- track request history in localStorage
- show historical requests per channel
- store history whenever a request or update is confirmed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f7b124e1c8325beb63aea119e9e28