### PR TITLE
Integrate search and channel requests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,10 +6,11 @@ import MaterialRequestForm from './components/MaterialRequestForm';
 import PdvUpdateForm from './components/PdvUpdateForm';
 import ConfirmationMessage from './components/ConfirmationMessage';
 import PreviousRequests from './components/PreviousRequests';
+import ChannelRequests from './components/ChannelRequests';
 import { getStorageItem, setStorageItem } from './utils/storage';
 
 const App = () => {
-  const [currentPage, setCurrentPage] = useState('home'); // 'home', 'trade-nacional', 'trade-regional', 'channel-select', 'location-select', 'pdv-actions', 'request-material', 'update-pdv', 'previous-requests', 'confirm-request', 'confirm-update'
+  const [currentPage, setCurrentPage] = useState('home'); // 'home', 'trade-nacional', 'trade-regional', 'channel-select', 'location-select', 'pdv-actions', 'request-material', 'update-pdv', 'previous-requests', 'channel-requests', 'confirm-request', 'confirm-update'
   const [selectedTradeType, setSelectedTradeType] = useState(''); // 'nacional' o 'regional'
   const [selectedChannelId, setSelectedChannelId] = useState('');
   const [selectedPdvId, setSelectedPdvId] = useState('');
@@ -40,6 +41,11 @@ const App = () => {
 
   const handleViewRequests = () => {
     setCurrentPage('previous-requests');
+  };
+
+  const handleViewChannelRequests = (channelId) => {
+    setSelectedChannelId(channelId);
+    setCurrentPage('channel-requests');
   };
 
   const handleConfirmRequest = (requestDetails) => {
@@ -83,6 +89,8 @@ const App = () => {
         return 'Actualizar PDV';
       case 'previous-requests':
         return 'Solicitudes Anteriores';
+      case 'channel-requests':
+        return 'Solicitudes por Canal';
       case 'confirm-request':
       case 'confirm-update':
         return 'Confirmación';
@@ -108,6 +116,9 @@ const App = () => {
         break;
       case 'previous-requests':
         setCurrentPage('pdv-actions');
+        break;
+      case 'channel-requests':
+        setCurrentPage('channel-select');
         break;
       case 'confirm-request':
       case 'confirm-update':
@@ -144,7 +155,7 @@ const App = () => {
         )}
 
         {currentPage === 'channel-select' && (
-          <ChannelSelector onSelectChannel={handleSelectChannel} />
+          <ChannelSelector onSelectChannel={handleSelectChannel} onViewChannelRequests={handleViewChannelRequests} />
         )}
 
         {currentPage === 'location-select' && (
@@ -178,7 +189,7 @@ const App = () => {
         )}
 
         {currentPage === 'request-material' && (
-          <MaterialRequestForm onConfirmRequest={handleConfirmRequest} selectedPdvId={selectedPdvId} />
+          <MaterialRequestForm onConfirmRequest={handleConfirmRequest} selectedPdvId={selectedPdvId} selectedChannelId={selectedChannelId} />
         )}
 
         {currentPage === 'update-pdv' && (
@@ -187,6 +198,10 @@ const App = () => {
 
         {currentPage === 'previous-requests' && (
           <PreviousRequests pdvId={selectedPdvId} onBack={handleBack} />
+        )}
+
+        {currentPage === 'channel-requests' && (
+          <ChannelRequests channelId={selectedChannelId} onBack={handleBack} />
         )}
 
         {(currentPage === 'confirm-request' || currentPage === 'confirm-update') && (

--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { getStorageItem } from '../utils/storage';
+import { channels } from '../mock/channels';
+
+const ChannelRequests = ({ channelId, onBack }) => {
+  const requests = getStorageItem('material-requests') || [];
+  const channelRequests = requests.filter((req) => req.channelId === channelId);
+  const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
+
+  return (
+    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8">
+      <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">
+        Solicitudes para {channelName}
+      </h2>
+      {channelRequests.length === 0 ? (
+        <p className="text-gray-600 text-center">No hay solicitudes previas para este canal.</p>
+      ) : (
+        <ul className="space-y-4">
+          {channelRequests.map((req, index) => (
+            <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
+              <p className="font-semibold text-gray-800">PDV: {req.pdvId}</p>
+              <ul className="ml-4 list-disc">
+                {req.items.map((item) => (
+                  <li key={item.id}>
+                    {item.material.name} - {item.measures.name} x {item.quantity}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        onClick={onBack}
+        className="w-full mt-6 bg-blue-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+      >
+        Volver
+      </button>
+    </div>
+  );
+};
+
+export default ChannelRequests;

--- a/src/components/ChannelSelector.js
+++ b/src/components/ChannelSelector.js
@@ -1,19 +1,28 @@
 import React from 'react';
 import { channels } from '../mock/channels';
 
-const ChannelSelector = ({ onSelectChannel }) => {
+const ChannelSelector = ({ onSelectChannel, onViewChannelRequests }) => {
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Selecciona un Canal</h2>
       <div className="grid grid-cols-1 gap-4">
         {channels.map((channel) => (
-          <button
-            key={channel.id}
-            onClick={() => onSelectChannel(channel.id)}
-            className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-all duration-300 ease-in-out transform hover:scale-105"
-          >
-            {channel.name}
-          </button>
+          <div key={channel.id} className="space-y-2">
+            <button
+              onClick={() => onSelectChannel(channel.id)}
+              className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-blue-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+            >
+              {channel.name}
+            </button>
+            {onViewChannelRequests && (
+              <button
+                onClick={() => onViewChannelRequests(channel.id)}
+                className="w-full bg-gray-500 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+              >
+                Ver Solicitudes
+              </button>
+            )}
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/MaterialRequestForm.js
+++ b/src/components/MaterialRequestForm.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { materials } from '../mock/materials';
 
-const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, onBackToPdvActions }) => {
+const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, selectedChannelId }) => {
   const [selectedMaterial, setSelectedMaterial] = useState('');
   const [quantity, setQuantity] = useState(1);
   const [selectedMeasures, setSelectedMeasures] = useState('');
   const [notes, setNotes] = useState('');
   const [cart, setCart] = useState([]);
+  const [materialSearch, setMaterialSearch] = useState('');
 
   const availableMeasures = [
     { id: 'medida-1', name: '60x90 cm' },
@@ -52,6 +53,7 @@ const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, onBackToPdvActio
     if (cart.length > 0) {
       onConfirmRequest({
         pdvId: selectedPdvId,
+        channelId: selectedChannelId,
         items: cart,
       });
     } else {
@@ -66,6 +68,15 @@ const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, onBackToPdvActio
         <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Solicitar Material POP</h2>
 
         <div className="mb-4">
+          <label htmlFor="material-search" className="block text-gray-700 text-sm font-bold mb-2">Buscar Material:</label>
+          <input
+            type="text"
+            id="material-search"
+            className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all duration-200 mb-2"
+            placeholder="Ingresa nombre del material"
+            value={materialSearch}
+            onChange={(e) => setMaterialSearch(e.target.value)}
+          />
           <label htmlFor="material-select" className="block text-gray-700 text-sm font-bold mb-2">Material:</label>
           <select
             id="material-select"
@@ -74,9 +85,11 @@ const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, onBackToPdvActio
             onChange={(e) => setSelectedMaterial(e.target.value)}
           >
             <option value="">Selecciona un material</option>
-            {materials.map((material) => (
-              <option key={material.id} value={material.id}>{material.name}</option>
-            ))}
+            {materials
+              .filter((material) => material.name.toLowerCase().includes(materialSearch.toLowerCase()))
+              .map((material) => (
+                <option key={material.id} value={material.id}>{material.name}</option>
+              ))}
           </select>
         </div>
 


### PR DESCRIPTION
## Summary
- add search functionality to MaterialRequestForm
- allow viewing requests per channel
- link channel requests from ChannelSelector
- forward channel info on material requests

## Testing
- `npm install`
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684f8a3f363883259ea7c9c54c0de45e