### PR TITLE
Update interface with modern Tigo style

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import LayoutHeader from './components/LayoutHeader';
+import LayoutFooter from './components/LayoutFooter';
 import ChannelSelector from './components/ChannelSelector';
 import LocationSelector from './components/LocationSelector';
 import MaterialRequestForm from './components/MaterialRequestForm';
@@ -130,7 +131,7 @@ const App = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col">
+    <div className="min-h-screen bg-tigo-light flex flex-col">
       <LayoutHeader title={getHeaderTitle()} onBack={currentPage !== 'home' ? handleBack : null} />
 
       <main className="flex-grow p-4 flex items-center justify-center">
@@ -208,6 +209,7 @@ const App = () => {
           <ConfirmationMessage message={confirmationMessage} onGoHome={handleGoHome} />
         )}
       </main>
+      <LayoutFooter />
     </div>
   );
 };

--- a/src/components/LayoutFooter.js
+++ b/src/components/LayoutFooter.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const LayoutFooter = () => (
+  <footer className="bg-gray-100 text-gray-500 text-center py-4 mt-auto">
+    <p className="text-sm">&copy; 2024 Tigo. Todos los derechos reservados.</p>
+  </footer>
+);
+
+export default LayoutFooter;

--- a/src/components/LayoutHeader.js
+++ b/src/components/LayoutHeader.js
@@ -2,7 +2,8 @@ import React from 'react';
 
 const LayoutHeader = ({ title, onBack }) => {
   return (
-    <header className="bg-tigo-blue text-white p-4 shadow-md flex items-center justify-between">
+    <header className="bg-tigo-blue text-white p-4 shadow-md flex items-center">
+      <img src="/tigo-logo.svg" alt="Tigo Logo" className="h-8 w-auto mr-4" />
       {onBack && (
         <button onClick={onBack} className="text-white text-2xl mr-4">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2.5" stroke="currentColor" className="w-6 h-6">
@@ -10,8 +11,7 @@ const LayoutHeader = ({ title, onBack }) => {
           </svg>
         </button>
       )}
-      <h1 className="text-2xl font-semibold flex-grow text-center">{title}</h1>
-      <img src="/tigo-logo.svg" alt="Tigo Logo" className="h-8 w-auto" />
+      <h1 className="text-xl md:text-2xl font-semibold flex-grow text-center">{title}</h1>
     </header>
   );
 };

--- a/src/components/MaterialRequestForm.js
+++ b/src/components/MaterialRequestForm.js
@@ -172,7 +172,7 @@ const MaterialRequestForm = ({ onConfirmRequest, selectedPdvId, selectedChannelI
               </button>
               <button
                 onClick={handleConfirmCart}
-                className="flex-1 bg-green-500 text-white py-2 px-4 rounded-lg shadow-md hover:bg-green-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+                className="flex-1 bg-tigo-cyan text-white py-2 px-4 rounded-lg shadow-md hover:bg-[#00a7d6] transition-all duration-300 ease-in-out transform hover:scale-105"
               >
                 Confirmar Solicitud Completa
               </button>

--- a/src/components/PdvUpdateForm.js
+++ b/src/components/PdvUpdateForm.js
@@ -92,7 +92,7 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
 
       <button
         onClick={handleSubmit}
-        className="w-full bg-purple-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-purple-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+        className="w-full bg-tigo-cyan text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00a7d6] transition-all duration-300 ease-in-out transform hover:scale-105"
       >
         Guardar Cambios
       </button>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,9 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'tigo-blue': '#0056A0'
+        'tigo-blue': '#0056A0',
+        'tigo-cyan': '#00C0F1',
+        'tigo-light': '#F5F7FA'
       },
       fontFamily: {
         sans: ['Poppins', 'ui-sans-serif', 'system-ui']


### PR DESCRIPTION
## Summary
- move Tigo logo to the left of the header
- add footer component with corporate copyright
- introduce accent color `tigo-cyan` and light background color
- highlight confirmation and update buttons using the new accent color
- apply corporate background color and layout footer in app

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684f96d02db08325b4fa2e284a2e731d