### PR TITLE
Update regions and show request dates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,9 +50,10 @@ const App = () => {
   };
 
   const handleConfirmRequest = (requestDetails) => {
-    console.log('Solicitud de Material Confirmada:', requestDetails);
+    const requestWithDate = { ...requestDetails, date: new Date().toISOString() };
+    console.log('Solicitud de Material Confirmada:', requestWithDate);
     const existing = getStorageItem('material-requests') || [];
-    setStorageItem('material-requests', [...existing, requestDetails]);
+    setStorageItem('material-requests', [...existing, requestWithDate]);
     setConfirmationMessage('¡Tu solicitud de material ha sido enviada con éxito!');
     setCurrentPage('confirm-request');
   };

--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -19,6 +19,7 @@ const ChannelRequests = ({ channelId, onBack }) => {
           {channelRequests.map((req, index) => (
             <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
               <p className="font-semibold text-gray-800">PDV: {req.pdvId}</p>
+              <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
               <ul className="ml-4 list-disc">
                 {req.items.map((item) => (
                   <li key={item.id}>

--- a/src/components/PdvUpdateForm.js
+++ b/src/components/PdvUpdateForm.js
@@ -35,6 +35,15 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
 
   const handleSubmit = () => {
     setStorageItem(`pdv-${selectedPdvId}-data`, pdvData);
+
+    const updates = getStorageItem('pdv-update-requests') || [];
+    const updateEntry = {
+      pdvId: selectedPdvId,
+      data: pdvData,
+      date: new Date().toISOString(),
+    };
+    setStorageItem('pdv-update-requests', [...updates, updateEntry]);
+
     onUpdateConfirm(pdvData);
   };
 

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -2,25 +2,49 @@ import React from 'react';
 import { getStorageItem } from '../utils/storage';
 
 const PreviousRequests = ({ pdvId, onBack }) => {
-  const requests = getStorageItem('material-requests') || [];
-  const pdvRequests = requests.filter((req) => req.pdvId === pdvId);
+  const materialRequests = getStorageItem('material-requests') || [];
+  const updateRequests = getStorageItem('pdv-update-requests') || [];
+  const pdvRequests = materialRequests.filter((req) => req.pdvId === pdvId);
+  const pdvUpdates = updateRequests.filter((req) => req.pdvId === pdvId);
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Solicitudes Anteriores</h2>
+      <h3 className="text-xl font-semibold text-gray-800 mb-4">Solicitudes de Material</h3>
       {pdvRequests.length === 0 ? (
-        <p className="text-gray-600 text-center">No hay solicitudes previas para este PDV.</p>
+        <p className="text-gray-600 text-center mb-6">No hay solicitudes previas para este PDV.</p>
       ) : (
-        <ul className="space-y-4">
+        <ul className="space-y-4 mb-6">
           {pdvRequests.map((req, index) => (
             <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
               <p className="font-semibold text-gray-800">Solicitud #{index + 1}</p>
+              <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
               <ul className="ml-4 list-disc">
                 {req.items.map((item) => (
                   <li key={item.id}>
                     {item.material.name} - {item.measures.name} x {item.quantity}
                   </li>
                 ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <h3 className="text-xl font-semibold text-gray-800 mb-4">Actualizaciones de PDV</h3>
+      {pdvUpdates.length === 0 ? (
+        <p className="text-gray-600 text-center">No hay actualizaciones previas para este PDV.</p>
+      ) : (
+        <ul className="space-y-4">
+          {pdvUpdates.map((update, index) => (
+            <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
+              <p className="font-semibold text-gray-800">Actualización #{index + 1}</p>
+              <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(update.date).toLocaleDateString()}</p>
+              <ul className="ml-4 list-disc">
+                <li>Nombre de Contacto: {update.data.contactName}</li>
+                <li>Teléfono: {update.data.contactPhone}</li>
+                <li>Dirección: {update.data.address}</li>
+                {update.data.notes && <li>Notas: {update.data.notes}</li>}
               </ul>
             </li>
           ))}

--- a/src/mock/locations.js
+++ b/src/mock/locations.js
@@ -1,13 +1,14 @@
 export const regions = [
-  { id: 'region-norte', name: 'Región Norte' },
+  { id: 'region-bogota', name: 'Bogotá' },
   { id: 'region-sur', name: 'Región Sur' },
   { id: 'region-centro', name: 'Región Centro' },
+  { id: 'region-andina', name: 'Andina' },
 ];
 
 export const subterritories = {
-  'region-norte': [
-    { id: 'sub-norte-1', name: 'Subterritorio Norte 1' },
-    { id: 'sub-norte-2', name: 'Subterritorio Norte 2' },
+  'region-bogota': [
+    { id: 'sub-bogota-1', name: 'Bogotá Zona 1' },
+    { id: 'sub-bogota-2', name: 'Bogotá Zona 2' },
   ],
   'region-sur': [
     { id: 'sub-sur-1', name: 'Subterritorio Sur 1' },
@@ -17,16 +18,20 @@ export const subterritories = {
     { id: 'sub-centro-1', name: 'Subterritorio Centro 1' },
     { id: 'sub-centro-2', name: 'Subterritorio Centro 2' },
   ],
+  'region-andina': [
+    { id: 'sub-andina-1', name: 'Subterritorio Andina 1' },
+    { id: 'sub-andina-2', name: 'Subterritorio Andina 2' },
+  ],
 };
 
 export const pdvs = {
-  'sub-norte-1': [
-    { id: 'pdv-n1-001', name: 'PDV Norte 1 - 001' },
-    { id: 'pdv-n1-002', name: 'PDV Norte 1 - 002' },
+  'sub-bogota-1': [
+    { id: 'pdv-b1-001', name: 'PDV Bogotá 1 - 001' },
+    { id: 'pdv-b1-002', name: 'PDV Bogotá 1 - 002' },
   ],
-  'sub-norte-2': [
-    { id: 'pdv-n2-001', name: 'PDV Norte 2 - 001' },
-    { id: 'pdv-n2-002', name: 'PDV Norte 2 - 002' },
+  'sub-bogota-2': [
+    { id: 'pdv-b2-001', name: 'PDV Bogotá 2 - 001' },
+    { id: 'pdv-b2-002', name: 'PDV Bogotá 2 - 002' },
   ],
   'sub-sur-1': [
     { id: 'pdv-s1-001', name: 'PDV Sur 1 - 001' },
@@ -43,5 +48,13 @@ export const pdvs = {
   'sub-centro-2': [
     { id: 'pdv-c2-001', name: 'PDV Centro 2 - 001' },
     { id: 'pdv-c2-002', name: 'PDV Centro 2 - 002' },
+  ],
+  'sub-andina-1': [
+    { id: 'pdv-a1-001', name: 'PDV Andina 1 - 001' },
+    { id: 'pdv-a1-002', name: 'PDV Andina 1 - 002' },
+  ],
+  'sub-andina-2': [
+    { id: 'pdv-a2-001', name: 'PDV Andina 2 - 001' },
+    { id: 'pdv-a2-002', name: 'PDV Andina 2 - 002' },
   ],
 };


### PR DESCRIPTION
## Summary
- add new regions Bogotá and Andina, remove Región Norte
- track creation date of material and PDV update requests
- save PDV updates in local storage
- display request dates and update history in Previous Requests
- show dates in Channel Requests list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684fb74d0a6c832595a0c56bd95869c2