### PR TITLE
Implement campaign management forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ Actualmente todos los datos se encuentran en archivos **mock** y se persisten te
 - **src/mock/campaigns.js** – Campañas de ejemplo usadas en el selector.
 - **src/components/HomeMenu.js** – Pantalla de inicio mejorada con bienvenida.
 - **src/components/CampaignsMenu.js** – Acceso a la creación y gestión de campañas.
+- **src/components/CreateCampaignForm.js** – Formulario para parametrizar campañas.
+- **src/components/ManageCampaigns.js** – Panel para editar campañas existentes.
 
 ## Conexión con backend
 
 1. **Carga de datos**: Los archivos de `src/mock` deben sustituirse por peticiones HTTP. Cada componente indica en sus comentarios dónde realizar esas llamadas.
 2. **Envío de solicitudes**: Las funciones `handleConfirmRequest` y `handleUpdateConfirm` dentro de `App.js` son los puntos principales para enviar información al servidor.
 3. **Históricos**: `PreviousRequests` y `ChannelRequests` leen datos del almacenamiento local; reemplazar por consultas al backend que filtren por PDV o canal.
+
+## Gestión de campañas
+
+El menú **Campañas** permite crear campañas asignando prioridad, canales y materiales a partir de los archivos de `src/mock`. Las campañas se almacenan en `localStorage` para efectos de prueba. Desde el backend se deberá implementar la persistencia y actualización real de estos datos.
 
 ## Puesta en marcha
 

--- a/src/components/CreateCampaignForm.js
+++ b/src/components/CreateCampaignForm.js
@@ -1,27 +1,119 @@
 import React, { useState } from 'react';
 import { campaigns } from '../mock/campaigns';
+import { channels } from '../mock/channels';
+import { materials } from '../mock/materials';
 
 /**
  * Formulario para crear una campaña nueva.
  * Guarda temporalmente la información en localStorage.
  */
 const CreateCampaignForm = ({ onBack }) => {
+  // Nombre de la campaña
   const [name, setName] = useState('');
+  // Prioridad única (1, 2 o 3)
+  const [priority, setPriority] = useState('1');
+  // Canales asociados
+  const [selectedChannels, setSelectedChannels] = useState([]);
+  // Materiales asignados
+  const [selectedMaterials, setSelectedMaterials] = useState([]);
+  // Búsqueda de materiales para filtrar la lista
+  const [materialSearch, setMaterialSearch] = useState('');
+
+  // Guarda la campaña en localStorage
   const handleSubmit = () => {
-    const newCampaign = { id: `camp-${Date.now()}`, name };
-    localStorage.setItem('campaigns', JSON.stringify([...(JSON.parse(localStorage.getItem('campaigns')) || campaigns), newCampaign]));
+    if (!name || selectedChannels.length === 0 || selectedMaterials.length === 0) {
+      alert('Completa todos los campos para guardar la campaña');
+      return;
+    }
+    const stored = JSON.parse(localStorage.getItem('campaigns')) || campaigns;
+    const newCampaign = {
+      id: `camp-${Date.now()}`,
+      name,
+      priority,
+      channels: selectedChannels,
+      materials: selectedMaterials,
+    };
+    localStorage.setItem('campaigns', JSON.stringify([...stored, newCampaign]));
     onBack();
   };
   return (
-    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto">
-      <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Crear campaña</h2>
+    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto space-y-4">
+      <h2 className="text-2xl font-semibold text-gray-800 text-center">Crear campaña</h2>
+
       <input
         type="text"
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder="Nombre de la campaña"
-        className="w-full mb-4 bg-gray-100 border border-gray-300 py-2 px-3 rounded-lg focus:outline-none"
+        className="w-full bg-gray-100 border border-gray-300 py-2 px-3 rounded-lg focus:outline-none"
       />
+
+      <div>
+        <h3 className="font-semibold mb-2">Prioridad</h3>
+        <select
+          className="w-full bg-gray-100 border border-gray-300 py-2 px-3 rounded-lg"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value)}
+        >
+          <option value="1">Prioridad 1</option>
+          <option value="2">Prioridad 2</option>
+          <option value="3">Prioridad 3</option>
+        </select>
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Canales</h3>
+        {channels.map((c) => (
+          <label key={c.id} className="block">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={selectedChannels.includes(c.id)}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setSelectedChannels([...selectedChannels, c.id]);
+                } else {
+                  setSelectedChannels(selectedChannels.filter((id) => id !== c.id));
+                }
+              }}
+            />
+            {c.name}
+          </label>
+        ))}
+      </div>
+
+      <div>
+        <h3 className="font-semibold mb-2">Materiales</h3>
+        <input
+          type="text"
+          placeholder="Buscar material"
+          value={materialSearch}
+          onChange={(e) => setMaterialSearch(e.target.value)}
+          className="w-full mb-2 bg-gray-100 border border-gray-300 py-1 px-2 rounded"
+        />
+        <div className="max-h-40 overflow-y-auto border border-gray-200 p-2 rounded">
+          {materials
+            .filter((m) => m.name.toLowerCase().includes(materialSearch.toLowerCase()))
+            .map((m) => (
+              <label key={m.id} className="block cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mr-2"
+                  checked={selectedMaterials.includes(m.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSelectedMaterials([...selectedMaterials, m.id]);
+                    } else {
+                      setSelectedMaterials(selectedMaterials.filter((id) => id !== m.id));
+                    }
+                  }}
+                />
+                {m.name}
+              </label>
+            ))}
+        </div>
+      </div>
+
       <div className="space-y-4">
         <button
           onClick={handleSubmit}

--- a/src/components/ManageCampaigns.js
+++ b/src/components/ManageCampaigns.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { campaigns as defaultCampaigns } from '../mock/campaigns';
+import { channels } from '../mock/channels';
+import { materials } from '../mock/materials';
 
 /**
  * Panel para editar o eliminar campañas existentes.
@@ -19,20 +21,80 @@ const ManageCampaigns = ({ onBack }) => {
     localStorage.setItem('campaigns', JSON.stringify(updated));
   };
 
+  const updateCampaign = (index, field, value) => {
+    const updated = [...list];
+    updated[index] = { ...updated[index], [field]: value };
+    setList(updated);
+    localStorage.setItem('campaigns', JSON.stringify(updated));
+  };
+
+  const toggleArrayValue = (array = [], value) =>
+    array.includes(value)
+      ? array.filter((v) => v !== value)
+      : [...array, value];
+
   return (
-    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto">
+    <div className="p-6 bg-white rounded-xl shadow-lg max-w-xl mx-auto">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Gestionar campañas</h2>
       {list.length === 0 ? (
         <p className="text-center text-gray-600">No hay campañas.</p>
       ) : (
-        <ul className="space-y-2 mb-4">
-          {list.map((c) => (
-            <li key={c.id} className="flex justify-between items-center bg-gray-50 p-2 rounded">
-              <span>{c.name}</span>
-              <button onClick={() => handleDelete(c.id)} className="text-red-500">Eliminar</button>
-            </li>
+        <div className="space-y-4 mb-4">
+          {list.map((c, idx) => (
+            <div key={c.id} className="border p-3 rounded">
+              <input
+                className="w-full mb-2 bg-gray-100 border border-gray-300 py-1 px-2 rounded"
+                value={c.name}
+                onChange={(e) => updateCampaign(idx, 'name', e.target.value)}
+              />
+              <div className="mb-2">
+                <h3 className="font-semibold text-sm">Prioridad</h3>
+                <select
+                  className="w-full bg-gray-100 border border-gray-300 py-1 px-2 rounded"
+                  value={c.priority}
+                  onChange={(e) => updateCampaign(idx, 'priority', e.target.value)}
+                >
+                  <option value="1">Prioridad 1</option>
+                  <option value="2">Prioridad 2</option>
+                  <option value="3">Prioridad 3</option>
+                </select>
+              </div>
+              <div className="mb-2">
+                <h3 className="font-semibold text-sm">Canales</h3>
+                {channels.map((ch) => (
+                  <label key={ch.id} className="block">
+                    <input
+                      type="checkbox"
+                      className="mr-2"
+                      checked={(c.channels || []).includes(ch.id)}
+                      onChange={() =>
+                        updateCampaign(idx, 'channels', toggleArrayValue(c.channels, ch.id))
+                      }
+                    />
+                    {ch.name}
+                  </label>
+                ))}
+              </div>
+              <div className="mb-2">
+                <h3 className="font-semibold text-sm">Materiales</h3>
+                {materials.map((m) => (
+                  <label key={m.id} className="block">
+                    <input
+                      type="checkbox"
+                      className="mr-2"
+                      checked={(c.materials || []).includes(m.id)}
+                      onChange={() =>
+                        updateCampaign(idx, 'materials', toggleArrayValue(c.materials, m.id))
+                      }
+                    />
+                    {m.name}
+                  </label>
+                ))}
+              </div>
+              <button onClick={() => handleDelete(c.id)} className="text-red-500 mt-2">Eliminar</button>
+            </div>
           ))}
-        </ul>
+        </div>
       )}
       <button onClick={onBack} className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all">
         Volver

--- a/src/mock/campaigns.js
+++ b/src/mock/campaigns.js
@@ -1,5 +1,26 @@
+// Campañas de ejemplo con prioridad, canales y materiales asignados.
+// Estas estructuras se almacenan temporalmente en localStorage
+// y pueden ser reemplazadas por datos provenientes de un backend.
 export const campaigns = [
-  { id: 'camp-1', name: 'Campaña Verano 2024' },
-  { id: 'camp-2', name: 'Promo Fin de Año' },
-  { id: 'camp-3', name: 'Lanzamiento Producto X' },
+  {
+    id: 'camp-1',
+    name: 'Campaña Verano 2024',
+    priority: '1',
+    channels: ['tiendas', 'tigo-express'],
+    materials: ['material-1', 'material-2'],
+  },
+  {
+    id: 'camp-2',
+    name: 'Promo Fin de Año',
+    priority: '2',
+    channels: ['dealer-home'],
+    materials: ['material-3'],
+  },
+  {
+    id: 'camp-3',
+    name: 'Lanzamiento Producto X',
+    priority: '3',
+    channels: ['fvd-home', 'islas'],
+    materials: ['material-4'],
+  },
 ];


### PR DESCRIPTION
## Summary
- extend mock campaign data to include priority, channels, and materials
- add full campaign creation form with priority, channels and materials selection
- enhance manage campaigns view to edit existing campaigns
- document campaign workflow in README

## Testing
- `npm run build`
- `npm test -- -w=0`


------
https://chatgpt.com/codex/tasks/task_e_686cb6dcfb5c83259ef99f426bf4451b