### PR TITLE
Move campaign actions to channel list

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -117,6 +117,11 @@ const App = () => {
     setCurrentPage('export-data');
   };
 
+  // Navegar directamente al formulario de creación de campaña
+  const handleCreateCampaign = () => {
+    setCurrentPage('create-campaign');
+  };
+
   // Exporta información de solicitudes y actualizaciones filtrando por canal,
   // puntos de venta y materiales. Se utiliza desde la pantalla de Export Data.
   const performExport = ({ channelId, pdvIds = [], materialIds = [] }) => {
@@ -310,7 +315,15 @@ const App = () => {
 
         {/* Listado de canales disponibles */}
         {isLoggedIn && currentPage === 'channel-select' && (
-          <ChannelSelector onSelectChannel={handleSelectChannel} />
+          <ChannelSelector
+            onSelectChannel={handleSelectChannel}
+            onCreateCampaign={
+              selectedTradeType === 'nacional' ? handleCreateCampaign : undefined
+            }
+            onExportData={
+              selectedTradeType === 'nacional' ? handleExportData : undefined
+            }
+          />
         )}
 
         {/* Menú del canal seleccionado */}
@@ -350,22 +363,6 @@ const App = () => {
               >
                 Ver Solicitudes Anteriores
               </button>
-              {selectedTradeType === 'nacional' && (
-                <>
-                  <button
-                    onClick={() => setCurrentPage('campaigns-menu')}
-                    className="w-full bg-indigo-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-indigo-600 transition-all duration-300 ease-in-out transform hover:scale-105"
-                  >
-                    Campañas
-                  </button>
-                  <button
-                    onClick={handleExportData}
-                    className="w-full bg-gray-600 text-white py-3 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all duration-300 ease-in-out transform hover:scale-105"
-                  >
-                    Exportar Datos
-                  </button>
-                </>
-              )}
             </div>
           </div>
         )}
@@ -405,7 +402,7 @@ const App = () => {
 
         {/* Crear campaña */}
         {isLoggedIn && currentPage === 'create-campaign' && (
-          <CreateCampaignForm onBack={handleBack} />
+          <CreateCampaignForm onBack={() => setCurrentPage('channel-select')} />
         )}
 
         {/* Gestionar campañas */}

--- a/src/components/ChannelSelector.js
+++ b/src/components/ChannelSelector.js
@@ -10,7 +10,9 @@ import { channels } from '../mock/channels';
  */
 
 // `onSelectChannel` cambia la vista al menú del canal seleccionado.
-const ChannelSelector = ({ onSelectChannel }) => {
+// `onCreateCampaign` y `onExportData` son opcionales y permiten acceder
+// directamente a la creación de campañas o a la exportación de datos.
+const ChannelSelector = ({ onSelectChannel, onCreateCampaign, onExportData }) => {
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-3xl mx-auto mt-8">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Selecciona un Canal</h2>
@@ -26,6 +28,26 @@ const ChannelSelector = ({ onSelectChannel }) => {
           </button>
         ))}
       </div>
+      {(onCreateCampaign || onExportData) && (
+        <div className="mt-6 flex flex-col sm:flex-row gap-4">
+          {onCreateCampaign && (
+            <button
+              onClick={onCreateCampaign}
+              className="w-full bg-indigo-500 text-white py-3 px-4 rounded-lg shadow-md hover:bg-indigo-600 transition-all duration-300 ease-in-out transform hover:scale-105"
+            >
+              Crear campaña
+            </button>
+          )}
+          {onExportData && (
+            <button
+              onClick={onExportData}
+              className="w-full bg-gray-600 text-white py-3 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all duration-300 ease-in-out transform hover:scale-105"
+            >
+              Exportar Datos
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add props to `ChannelSelector` for new actions
- provide buttons to create campaigns and export data from trade
- expose a direct handler to create campaigns
- relocate campaign creation from PDV actions

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686d71109d608325b596f4fd1b7ab56e