### PR TITLE
Add home button via Tigo logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Actualmente todos los datos se encuentran en archivos **mock** y se persisten te
 - **src/utils/storage.js** – Utilidades para leer y escribir en `localStorage`.
 - **src/mock/campaigns.js** – Campañas de ejemplo usadas en el selector.
 - **src/components/HomeMenu.js** – Pantalla de inicio mejorada con bienvenida.
+- **src/assets/TigoLogo.js** – Representación SVG del logo usada en el encabezado.
+- El logo en el encabezado funciona como botón para volver al menú principal.
 - **src/components/CampaignsMenu.js** – Acceso a la creación y gestión de campañas.
 - **src/components/CreateCampaignForm.js** – Formulario para parametrizar campañas.
 - **src/components/ManageCampaigns.js** – Panel para editar campañas existentes.

--- a/public/tigo-logo.svg
+++ b/public/tigo-logo.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none">
-  <rect width="120" height="40" rx="6" fill="#0056A0"/>
-  <text x="50%" y="50%" fill="white" font-family="Arial, sans-serif" font-size="20" dominant-baseline="middle" text-anchor="middle">Tigo</text>
-</svg>

--- a/src/App.js
+++ b/src/App.js
@@ -299,6 +299,7 @@ const App = () => {
     <div className="min-h-screen bg-tigo-light flex flex-col">
       <LayoutHeader
         title={getHeaderTitle()}
+        onLogoClick={isLoggedIn ? handleGoHome : null}
         onBack={isLoggedIn && currentPage !== 'home' ? handleBack : null}
         onLogout={isLoggedIn ? handleLogout : null}
       />

--- a/src/assets/TigoLogo.js
+++ b/src/assets/TigoLogo.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+/**
+ * Logo de Tigo representado como SVG para usarlo como componente React.
+ * Se acepta una clase opcional para controlar el tamano desde Tailwind.
+ */
+const TigoLogo = ({ className = '' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 120 40"
+    fill="none"
+    className={className}
+  >
+    <rect width="120" height="40" rx="6" fill="#0056A0" />
+    <text
+      x="50%"
+      y="50%"
+      fill="white"
+      fontFamily="Arial, sans-serif"
+      fontSize="20"
+      dominantBaseline="middle"
+      textAnchor="middle"
+    >
+      Tigo
+    </text>
+  </svg>
+);
+
+export default TigoLogo;

--- a/src/components/HomeMenu.js
+++ b/src/components/HomeMenu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import NacionalPlaceholder from '../assets/NacionalPlaceholder';
 import RegionalPlaceholder from '../assets/RegionalPlaceholder';
+import TigoLogo from '../assets/TigoLogo';
 
 const HomeMenu = ({ onSelectTrade }) => {
   const today = new Date().toLocaleDateString();
@@ -8,7 +9,7 @@ const HomeMenu = ({ onSelectTrade }) => {
   return (
     <div className="w-full max-w-4xl mx-auto bg-white rounded-xl shadow-lg overflow-hidden">
       <div className="text-center p-6 space-y-2">
-        <img src="/tigo-logo.svg" alt="Tigo" className="h-12 mx-auto" />
+        <TigoLogo className="h-12 mx-auto" />
         <h2 className="text-3xl font-bold text-gray-800">BASE DE DESTINATARIOS</h2>
         <p className="text-sm text-gray-600">{today}</p>
         <p className="text-gray-700 max-w-2xl mx-auto">

--- a/src/components/LayoutHeader.js
+++ b/src/components/LayoutHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import TigoLogo from '../assets/TigoLogo';
 
 /**
  * Encabezado común de la aplicación.
@@ -6,10 +7,12 @@ import React from 'react';
  * `onBack` está definido.
  */
 
-const LayoutHeader = ({ title, onBack, onLogout }) => {
+const LayoutHeader = ({ title, onBack, onLogout, onLogoClick }) => {
   return (
     <header className="bg-tigo-blue text-white p-4 shadow-md flex items-center">
-      <img src="/tigo-logo.svg" alt="Tigo Logo" className="h-8 w-auto mr-4" />
+      <button onClick={onLogoClick} className="mr-4 focus:outline-none">
+        <TigoLogo className="h-8 w-auto" />
+      </button>
       {onBack && (
         <button onClick={onBack} className="text-white text-2xl mr-4">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="2.5" stroke="currentColor" className="w-6 h-6">

--- a/src/components/LoginScreen.js
+++ b/src/components/LoginScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import TigoLogo from '../assets/TigoLogo';
 
 /**
  * Pantalla de inicio de sesión.
@@ -22,7 +23,7 @@ const LoginScreen = ({ onLogin }) => {
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto text-center space-y-4">
-      <img src="/tigo-logo.svg" alt="Tigo Logo" className="h-12 mx-auto" />
+      <TigoLogo className="h-12 mx-auto" />
       <h2 className="text-2xl font-semibold text-gray-800">Iniciar Sesión</h2>
       {error && <p className="text-red-600 text-sm">{error}</p>}
       <input


### PR DESCRIPTION
## Summary
- add `TigoLogo` React component with inline SVG
- use clickable logo in `LayoutHeader`
- pass home navigation handler to header
- replace image usage with component in `HomeMenu` and `LoginScreen`
- remove unused `public/tigo-logo.svg`
- document the new logo component and its behaviour

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7673def88325978ade46779f8a48