### PR TITLE
Add stock-based material selection

### DIFF
--- a/src/components/ManageCampaigns.js
+++ b/src/components/ManageCampaigns.js
@@ -29,9 +29,18 @@ const ManageCampaigns = ({ onBack }) => {
   };
 
   const toggleArrayValue = (array = [], value) =>
-    array.includes(value)
-      ? array.filter((v) => v !== value)
-      : [...array, value];
+    array.includes(value) ? array.filter((v) => v !== value) : [...array, value];
+
+  const getMaterialIds = (list = []) =>
+    list.map((m) => (typeof m === 'object' ? m.id : m));
+
+  const toggleMaterialValue = (list = [], value) => {
+    const ids = getMaterialIds(list);
+    if (ids.includes(value)) {
+      return list.filter((m) => (typeof m === 'object' ? m.id : m) !== value);
+    }
+    return [...list, { id: value, quantity: 1 }];
+  };
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-xl mx-auto">
@@ -68,7 +77,11 @@ const ManageCampaigns = ({ onBack }) => {
                       className="mr-2"
                       checked={(c.channels || []).includes(ch.id)}
                       onChange={() =>
-                        updateCampaign(idx, 'channels', toggleArrayValue(c.channels, ch.id))
+                        updateCampaign(
+                          idx,
+                          'channels',
+                          toggleArrayValue(c.channels, ch.id),
+                        )
                       }
                     />
                     {ch.name}
@@ -82,9 +95,13 @@ const ManageCampaigns = ({ onBack }) => {
                     <input
                       type="checkbox"
                       className="mr-2"
-                      checked={(c.materials || []).includes(m.id)}
+                      checked={getMaterialIds(c.materials || []).includes(m.id)}
                       onChange={() =>
-                        updateCampaign(idx, 'materials', toggleArrayValue(c.materials, m.id))
+                        updateCampaign(
+                          idx,
+                          'materials',
+                          toggleMaterialValue(c.materials, m.id),
+                        )
                       }
                     />
                     {m.name}

--- a/src/components/MaterialSelectorModal.js
+++ b/src/components/MaterialSelectorModal.js
@@ -5,8 +5,9 @@ import React from 'react';
  */
 const MaterialSelectorModal = ({
   materials = [],
-  selectedMaterials = [],
+  selectedMaterials = {},
   onToggle,
+  onQuantityChange,
   search,
   setSearch,
   onClose,
@@ -24,20 +25,37 @@ const MaterialSelectorModal = ({
         onChange={(e) => setSearch(e.target.value)}
         className="w-full mb-2 bg-gray-100 border border-gray-300 py-1 px-2 rounded"
       />
-      <div className="max-h-60 overflow-y-auto border border-gray-200 p-2 rounded">
+      <div className="max-h-60 overflow-y-auto border border-gray-200 p-2 rounded space-y-2">
         {materials
           .filter((m) => m.name.toLowerCase().includes(search.toLowerCase()))
-          .map((m) => (
-            <label key={m.id} className="block cursor-pointer">
-              <input
-                type="checkbox"
-                className="mr-2"
-                checked={selectedMaterials.includes(m.id)}
-                onChange={() => onToggle(m.id)}
-              />
-              {m.name}
-            </label>
-          ))}
+          .map((m) => {
+            const isSelected = Object.prototype.hasOwnProperty.call(selectedMaterials, m.id);
+            return (
+              <div key={m.id} className="flex items-center justify-between">
+                <label className={`flex-1 cursor-pointer ${m.stock === 0 ? 'text-gray-400' : ''}`}>
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={isSelected}
+                    disabled={m.stock === 0}
+                    onChange={() => onToggle(m.id, m.stock)}
+                  />
+                  {m.name} <span className="text-xs text-gray-500">(Disponibles: {m.stock})</span>
+                </label>
+                {isSelected && m.stock > 0 && (
+                  <input
+                    type="number"
+                    min="1"
+                    max={m.stock}
+                    value={selectedMaterials[m.id]}
+                    onChange={(e) => onQuantityChange(m.id, Math.min(m.stock, Math.max(1, parseInt(e.target.value) || 1)))}
+                    className="w-20 bg-gray-100 border border-gray-300 p-1 rounded ml-2"
+                  />
+                )}
+                {m.stock === 0 && <span className="text-xs ml-2">Sin stock disponible</span>}
+              </div>
+            );
+          })}
       </div>
       <button
         onClick={onClose}

--- a/src/mock/materials.js
+++ b/src/mock/materials.js
@@ -1,6 +1,26 @@
 export const materials = [
-  { id: 'material-1', name: 'Afiche Promocional', description: 'Afiche para promociones de temporada.' },
-  { id: 'material-2', name: 'Volante Informativo', description: 'Volante con información de nuevos planes.' },
-  { id: 'material-3', name: 'Display de Mesa', description: 'Pequeño display acrílico para mostradores.' },
-  { id: 'material-4', name: 'Banner Roll-up', description: 'Banner portátil para eventos.' },
+  {
+    id: 'material-1',
+    name: 'Afiche Promocional',
+    description: 'Afiche para promociones de temporada.',
+    stock: 20,
+  },
+  {
+    id: 'material-2',
+    name: 'Volante Informativo',
+    description: 'Volante con información de nuevos planes.',
+    stock: 50,
+  },
+  {
+    id: 'material-3',
+    name: 'Display de Mesa',
+    description: 'Pequeño display acrílico para mostradores.',
+    stock: 0,
+  },
+  {
+    id: 'material-4',
+    name: 'Banner Roll-up',
+    description: 'Banner portátil para eventos.',
+    stock: 5,
+  },
 ];


### PR DESCRIPTION
## Summary
- add stock field to materials mock data
- handle quantity selection in `MaterialSelectorModal`
- track selected material quantities in `CreateCampaignForm`
- adjust campaign manager to support material objects with quantities

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687f3f07885c83259b75d7b4560cb348