### PR TITLE
Enable custom quote materials

### DIFF
--- a/src/components/CreateCampaignForm.js
+++ b/src/components/CreateCampaignForm.js
@@ -66,6 +66,14 @@ const CreateCampaignForm = ({ onBack }) => {
         result[id].push(ch);
       });
     });
+    materials.forEach((m) => {
+      if (m.requiresCotizacion && m.canalesPermitidos) {
+        if (!result[m.id]) result[m.id] = [];
+        m.canalesPermitidos.forEach((ch) => {
+          if (!result[m.id].includes(ch)) result[m.id].push(ch);
+        });
+      }
+    });
     return materials.map((m) => ({
       ...m,
       channels: result[m.id]?.map(
@@ -135,8 +143,10 @@ const CreateCampaignForm = ({ onBack }) => {
               const mat = materialsWithChannels.find((m) => m.id === id);
               return (
                 <li key={id}>
-                  {mat?.name || id} (
-                  {mat?.channels ? mat.channels.join(', ') : ''}) - {qty}
+                  {mat?.name || id}{' '}
+                  {mat?.requiresCotizacion &&
+                    '(Cotizable – sin stock predeterminado) '}
+                  ({mat?.channels ? mat.channels.join(', ') : ''}) - {qty}
                 </li>
               );
             })}

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -22,6 +22,14 @@ const ExportData = ({ onBack, onExport }) => {
         result[id].push(ch);
       });
     });
+    materials.forEach((m) => {
+      if (m.requiresCotizacion && m.canalesPermitidos) {
+        if (!result[m.id]) result[m.id] = [];
+        m.canalesPermitidos.forEach((ch) => {
+          if (!result[m.id].includes(ch)) result[m.id].push(ch);
+        });
+      }
+    });
     return result;
   }, []);
 
@@ -97,6 +105,11 @@ const ExportData = ({ onBack, onExport }) => {
                   }
                 />
                 {m.name}{' '}
+                {m.requiresCotizacion && (
+                  <span className="text-xs text-gray-500">
+                    (Cotizable – sin stock predeterminado)
+                  </span>
+                )}{' '}
                 <span className="text-xs text-gray-500">
                   (
                   {(channelsByMaterial[m.id] || [])

--- a/src/components/ManageCampaigns.js
+++ b/src/components/ManageCampaigns.js
@@ -19,6 +19,14 @@ const ManageCampaigns = ({ onBack }) => {
         result[id].push(ch);
       });
     });
+    materials.forEach((m) => {
+      if (m.requiresCotizacion && m.canalesPermitidos) {
+        if (!result[m.id]) result[m.id] = [];
+        m.canalesPermitidos.forEach((ch) => {
+          if (!result[m.id].includes(ch)) result[m.id].push(ch);
+        });
+      }
+    });
     return result;
   }, []);
 
@@ -117,6 +125,11 @@ const ManageCampaigns = ({ onBack }) => {
                       }
                     />
                     {m.name}{' '}
+                    {m.requiresCotizacion && (
+                      <span className="text-xs text-gray-500">
+                        (Cotizable – sin stock predeterminado)
+                      </span>
+                    )}
                     <span className="text-xs text-gray-500">
                       (
                       {(channelsByMaterial[m.id] || [])

--- a/src/components/MaterialRequestForm.js
+++ b/src/components/MaterialRequestForm.js
@@ -53,8 +53,18 @@ const MaterialRequestForm = ({
 
   const allowedMaterials = channelMaterials[selectedChannelId] || [];
   const allowedIds = allowedMaterials.map((m) => m.id);
+  const cotizableMaterials = materials.filter(
+    (m) =>
+      m.requiresCotizacion &&
+      (m.canalesPermitidos || []).includes(selectedChannelId),
+  );
   const materialsForChannel = materials
-    .filter((m) => allowedIds.includes(m.id))
+    .filter(
+      (m) =>
+        allowedIds.includes(m.id) ||
+        (m.requiresCotizacion &&
+          (m.canalesPermitidos || []).includes(selectedChannelId)),
+    )
     .map((m) => ({
       ...m,
       stock: allowedMaterials.find((am) => am.id === m.id)?.stock || m.stock,
@@ -83,13 +93,17 @@ const availableMeasures = [
 
   // Agrega el material actual al carrito de la solicitud
   const handleAddToCart = () => {
+    const materialDetails = materials.find((m) => m.id === selectedMaterial);
+    const isAllowed =
+      allowedIds.includes(selectedMaterial) ||
+      (materialDetails?.requiresCotizacion &&
+        (materialDetails.canalesPermitidos || []).includes(selectedChannelId));
     if (
       selectedMaterial &&
       quantity > 0 &&
       (selectedMeasures || customMeasure) &&
-      allowedIds.includes(selectedMaterial)
+      isAllowed
     ) {
-      const materialDetails = materials.find((m) => m.id === selectedMaterial);
       const measureDetails =
         selectedMeasures === 'otro'
           ? { id: 'otro', name: customMeasure || 'Personalizado' }
@@ -132,7 +146,12 @@ const availableMeasures = [
       ...item,
       id: `${item.material.id}-${Date.now()}-${Math.random()}`,
     }));
-    const filtered = newItems.filter((it) => allowedIds.includes(it.material.id));
+    const filtered = newItems.filter(
+      (it) =>
+        allowedIds.includes(it.material.id) ||
+        (it.material.requiresCotizacion &&
+          (it.material.canalesPermitidos || []).includes(selectedChannelId)),
+    );
     if (filtered.length < newItems.length) {
       alert('Algunos materiales no pertenecen al canal actual y fueron omitidos');
     }
@@ -187,8 +206,11 @@ const availableMeasures = [
           </button>
           {selectedMaterial && (
             <p className="text-sm text-gray-600 mt-1">
-              Pertenece al canal {channelName}. Stock disponible:{' '}
-              {allowedMaterials.find((m) => m.id === selectedMaterial)?.stock || 0}
+              {materials.find((m) => m.id === selectedMaterial)?.requiresCotizacion
+                ? 'Este material será cotizado y producido bajo pedido por Trade Nacional.'
+                : `Pertenece al canal ${channelName}. Stock disponible: ${
+                    allowedMaterials.find((m) => m.id === selectedMaterial)?.stock || 0
+                  }`}
             </p>
           )}
         </div>

--- a/src/components/MaterialSelectorModal.js
+++ b/src/components/MaterialSelectorModal.js
@@ -32,33 +32,47 @@ const MaterialSelectorModal = ({
             const isSelected = Object.prototype.hasOwnProperty.call(selectedMaterials, m.id);
             return (
               <div key={m.id} className="flex items-center justify-between">
-                <label className={`flex-1 cursor-pointer ${m.stock === 0 ? 'text-gray-400' : ''}`}>
+                <label className={`flex-1 cursor-pointer ${m.stock === 0 && !m.requiresCotizacion ? 'text-gray-400' : ''}`}>
                   <input
                     type="checkbox"
                     className="mr-2"
                     checked={isSelected}
-                    disabled={m.stock === 0}
+                    disabled={m.stock === 0 && !m.requiresCotizacion}
                     onChange={() => onToggle(m.id, m.stock)}
                   />
                   {m.name}{' '}
+                  {m.requiresCotizacion && (
+                    <span className="text-xs text-gray-500">(Cotizable – sin stock predeterminado)</span>
+                  )}{' '}
                   {m.channels && (
                     <span className="text-xs text-gray-500">
                       ({m.channels.join(', ')})
                     </span>
-                  )}{' '}
-                  <span className="text-xs text-gray-500">(Disponibles: {m.stock})</span>
+                  )}
+                  {!m.requiresCotizacion && (
+                    <span className="text-xs text-gray-500">(Disponibles: {m.stock})</span>
+                  )}
                 </label>
-                {isSelected && m.stock > 0 && (
+                {isSelected && (m.stock > 0 || m.requiresCotizacion) && (
                   <input
                     type="number"
                     min="1"
-                    max={m.stock}
+                    {...(!m.requiresCotizacion ? { max: m.stock } : {})}
                     value={selectedMaterials[m.id]}
-                    onChange={(e) => onQuantityChange(m.id, Math.min(m.stock, Math.max(1, parseInt(e.target.value) || 1)))}
+                    onChange={(e) =>
+                      onQuantityChange(
+                        m.id,
+                        m.requiresCotizacion
+                          ? Math.max(1, parseInt(e.target.value) || 1)
+                          : Math.min(m.stock, Math.max(1, parseInt(e.target.value) || 1)),
+                      )
+                    }
                     className="w-20 bg-gray-100 border border-gray-300 p-1 rounded ml-2"
                   />
                 )}
-                {m.stock === 0 && <span className="text-xs ml-2">Sin stock disponible</span>}
+                {m.stock === 0 && !m.requiresCotizacion && (
+                  <span className="text-xs ml-2">Sin stock disponible</span>
+                )}
               </div>
             );
           })}

--- a/src/mock/materials.js
+++ b/src/mock/materials.js
@@ -16,12 +16,16 @@ export const materials = [
     name: 'Display de Mesa',
     description: 'Pequeño display acrílico para mostradores.',
     stock: 0,
+    requiresCotizacion: true,
+    canalesPermitidos: ['tiendas', 'tigo-express'],
   },
   {
     id: 'material-4',
     name: 'Banner Roll-up',
     description: 'Banner portátil para eventos.',
     stock: 5,
+    requiresCotizacion: true,
+    canalesPermitidos: ['tiendas', 'tigo-express', 'islas', 'fvd-home', 'dealer-home'],
   },
 
   { id: 'material-101', name: 'VOLANTES HOME HCF', description: 'Medidas: 8 x 13 cm', stock: 17850 },


### PR DESCRIPTION
## Summary
- support materials with `requiresCotizacion` flag and allowed channels
- handle these quote-only items in request form
- label quote-only materials in campaign creation and management tools
- adjust material selection modal to allow items without stock
- expose cotizable flag in export view

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887daa971bc8325adb63840516f87a8