### PR TITLE
Implement measure selection in campaign creation

### DIFF
--- a/src/components/MaterialSelectorModal.js
+++ b/src/components/MaterialSelectorModal.js
@@ -58,7 +58,7 @@ const MaterialSelectorModal = ({
                     type="number"
                     min="1"
                     {...(!m.requiresCotizacion ? { max: m.stock } : {})}
-                    value={selectedMaterials[m.id]}
+                    value={selectedMaterials[m.id]?.quantity}
                     onChange={(e) =>
                       onQuantityChange(
                         m.id,


### PR DESCRIPTION
## Summary
- allow CreateCampaignForm to handle measures per material
- keep quantity selection modal compatible with new state
- require measure or custom measure when saving a campaign

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6888eff750788325853893f2c066d230