### PR TITLE
Implement Excel export for structured requests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,7 @@ import LoginScreen from './components/LoginScreen';
 import ChannelMenu from './components/ChannelMenu';
 import Sidebar from './components/Sidebar';
 import { getStorageItem, setStorageItem } from './utils/storage';
+import exportToExcel from './utils/exportToExcel';
 import { channels } from './mock/channels';
 
 const App = () => {
@@ -127,7 +128,7 @@ const App = () => {
   // puntos de venta y materiales. Se utiliza desde la pantalla de Export Data.
   const performExport = (params) => {
     if (params && params.type) {
-      console.log('Export data ready:', params);
+      exportToExcel(params);
       return;
     }
     const { channelId, pdvIds = [], materialIds = [] } = params;

--- a/src/utils/exportToExcel.js
+++ b/src/utils/exportToExcel.js
@@ -1,0 +1,48 @@
+import * as XLSX from 'xlsx';
+
+/**
+ * Exporta un objeto de solicitud de materiales a un archivo Excel (.xlsx).
+ * Cada combinación de PDV y material se convierte en una fila del archivo.
+ *
+ * @param {Object} exportObj - Objeto estructurado con la información a exportar
+ */
+export default function exportToExcel(exportObj) {
+  if (!exportObj || !Array.isArray(exportObj.pdvs)) {
+    return;
+  }
+
+  // Definir columnas y generar filas
+  const rows = [];
+  exportObj.pdvs.forEach((pdv) => {
+    const zone = Array.isArray(pdv.zone) ? pdv.zone.join(', ') : pdv.zone || '';
+    const campaigns = Array.isArray(pdv.campaigns)
+      ? pdv.campaigns.join(', ')
+      : pdv.campaigns || '';
+    pdv.materials.forEach((mat) => {
+      rows.push({
+        Fecha: exportObj.requestDate,
+        'Tipo de solicitud': exportObj.type,
+        Canal: exportObj.channelName,
+        Región: pdv.regionName,
+        Subterritorio: pdv.subterritoryName,
+        PDV: pdv.name,
+        Material: mat.name,
+        Cantidad: mat.quantity || '',
+        Medida: mat.measure || '',
+        '¿Cotizable?': mat.requiresCotizacion ? 'Sí' : 'No',
+        Zona: zone,
+        Prioridad: pdv.priority || '',
+        Campaña: campaigns,
+        Observaciones: mat.observations || '',
+      });
+    });
+  });
+
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Solicitud');
+
+  const timestamp = new Date().toISOString();
+  const filename = `Solicitud_Material_${timestamp}.xlsx`;
+  XLSX.writeFile(workbook, filename);
+}


### PR DESCRIPTION
## Summary
- add `exportToExcel` helper to convert requests to XLSX
- invoke Excel export from `App.performExport`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bbf140c3083258abfd7c243914849