### PR TITLE
Improve PDV update defaults workflow

### DIFF
--- a/src/components/PdvUpdateForm.js
+++ b/src/components/PdvUpdateForm.js
@@ -25,10 +25,9 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
   });
   // Campo que se está editando actualmente
   const [editingField, setEditingField] = useState(null);
-  // Controla la visualización del formulario para agregar campos extra
-  const [addingField, setAddingField] = useState(false);
-  const [newFieldLabel, setNewFieldLabel] = useState('');
-  const [newFieldValue, setNewFieldValue] = useState('');
+  // Estado para controlar la ventana de confirmación
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [defaultAction, setDefaultAction] = useState('none'); // new | replace | none
   // Conjunto de datos predeterminados almacenados para el PDV
   const [pdvDefaultsList, setPdvDefaultsList] = useState([]);
   // Permite indicar si los cambios actuales se deben guardar como predeterminados
@@ -80,26 +79,36 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
     });
   };
 
-  // Agrega un nuevo campo adicional al formulario
-  const handleAddField = () => {
-    if (!newFieldLabel.trim()) return;
-    setPdvData((prev) => ({
-      ...prev,
-      additionalFields: [
-        ...prev.additionalFields,
-        { label: newFieldLabel, value: newFieldValue },
-      ],
-    }));
-    setNewFieldLabel('');
-    setNewFieldValue('');
-    setAddingField(false);
-  };
+
+  // Determina si existe un set de predeterminados muy similar
+  const findSimilarDefaultsIndex = (data, list) =>
+    list.findIndex((def) => {
+      let match = 0;
+      if ((def.contactName || '') === (data.contactName || '')) match++;
+      if ((def.contactPhone || '') === (data.contactPhone || '')) match++;
+      if ((def.city || '') === (data.city || '')) match++;
+      if ((def.address || '') === (data.address || '')) match++;
+      return match >= 3;
+    });
 
   // Guarda un conjunto de datos predeterminados para el PDV
   const savePdvDefaults = (data) => {
     const list = getStorageItem(`pdv-${selectedPdvId}-defaults-list`) || [];
-    const entry = { ...data, savedAt: new Date().toISOString() };
-    const newList = [...list, entry];
+    const entry = {
+      ...data,
+      savedAt: new Date().toISOString(),
+      autoLabel: `PDV: ${data.city} – ${data.contactName}`,
+    };
+    const idx = findSimilarDefaultsIndex(data, list);
+    let newList;
+    if (idx !== -1) {
+      console.log('Reemplazando set predeterminado existente en índice', idx);
+      newList = [...list];
+      newList[idx] = entry;
+    } else {
+      console.log('Guardando nuevo set de datos predeterminados');
+      newList = [...list, entry];
+    }
     setPdvDefaultsList(newList);
     setStorageItem(`pdv-${selectedPdvId}-defaults-list`, newList);
   };
@@ -130,7 +139,7 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
     setStorageItem(`pdv-${selectedPdvId}-defaults-list`, updated);
   };
 
-  // Guarda la información editada y notifica al componente padre
+  // Abre el modal de confirmación
   const handleSubmit = () => {
     if (
       !pdvData.contactName.trim() ||
@@ -142,6 +151,19 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
       return;
     }
 
+    if (saveAsDefault) {
+      const list = getStorageItem(`pdv-${selectedPdvId}-defaults-list`) || [];
+      const idx = findSimilarDefaultsIndex(pdvData, list);
+      setDefaultAction(idx !== -1 ? 'replace' : 'new');
+    } else {
+      setDefaultAction('none');
+    }
+
+    setShowConfirm(true);
+  };
+
+  // Ejecuta el guardado definitivo
+  const finalizeSubmit = () => {
     setStorageItem(`pdv-${selectedPdvId}-data`, pdvData);
     if (saveAsDefault) {
       savePdvDefaults(pdvData);
@@ -156,6 +178,7 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
     };
     setStorageItem('pdv-update-requests', [...updates, updateEntry]);
 
+    setShowConfirm(false);
     onUpdateConfirm(pdvData);
   };
 
@@ -201,9 +224,10 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
           <span className="text-gray-900">{pdvData[fieldName] || '-'}</span>
           <button
             onClick={() => setEditingField(fieldName)}
-            className="text-tigo-blue text-sm underline"
+            className="text-tigo-blue text-sm underline flex items-center space-x-1"
           >
-            Editar
+            <span>✎</span>
+            <span>Editar</span>
           </button>
         </div>
       )}
@@ -218,6 +242,7 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
 
       <div className="md:flex md:space-x-6">
         <div className="flex-1">
+          <h3 className="text-lg font-semibold mb-4">Datos actuales del PDV</h3>
           {renderField('Nombre de Contacto', 'contactName')}
           {renderField('Teléfono de Contacto', 'contactPhone')}
           {renderField('Ciudad', 'city')}
@@ -261,60 +286,16 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
                   <span className="text-gray-900">{field.value || '-'}</span>
                   <button
                     onClick={() => setEditingField(`additional-${index}`)}
-                    className="text-tigo-blue text-sm underline"
+                    className="text-tigo-blue text-sm underline flex items-center space-x-1"
                   >
-                    Editar
+                    <span>✎</span>
+                    <span>Editar</span>
                   </button>
                 </div>
               )}
             </div>
           ))}
 
-          {addingField ? (
-            <div className="mb-4">
-              <input
-                type="text"
-                placeholder="Nombre del Campo"
-                className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-tigo-blue transition-all duration-200 mb-2"
-                value={newFieldLabel}
-                onChange={(e) => setNewFieldLabel(e.target.value)}
-              />
-              <input
-                type="text"
-                placeholder="Valor"
-                className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg focus:outline-none focus:ring-2 focus:ring-tigo-blue transition-all duration-200 mb-2"
-                value={newFieldValue}
-                onChange={(e) => setNewFieldValue(e.target.value)}
-              />
-              <div className="flex justify-end mt-2 space-x-2">
-                <button
-                  onClick={() => {
-                    setAddingField(false);
-                    setNewFieldLabel('');
-                    setNewFieldValue('');
-                  }}
-                  className="bg-gray-300 text-gray-700 py-1 px-3 rounded-md"
-                >
-                  Cancelar
-                </button>
-                <button
-                  onClick={handleAddField}
-                  className="bg-green-500 text-white py-1 px-3 rounded-md"
-                >
-                  Agregar
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="mb-4">
-              <button
-                onClick={() => setAddingField(true)}
-                className="bg-tigo-cyan text-white py-2 px-4 rounded-lg shadow-md hover:bg-[#00a7d6] transition-all duration-300"
-              >
-                Agregar Campo
-              </button>
-            </div>
-          )}
 
           <div className="mb-4 flex items-center space-x-2">
             <input
@@ -337,11 +318,12 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
         </div>
 
         {pdvDefaultsList.length > 0 && (
-          <div className="mt-6 md:mt-0 md:w-1/3 bg-gray-50 border rounded-lg p-4">
-            <h3 className="text-lg font-semibold mb-2">Datos predeterminados del PDV</h3>
-            <ul className="space-y-4 text-sm max-h-80 overflow-y-auto">
+          <div className="mt-6 md:mt-0 md:w-1/3 bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <h3 className="text-lg font-semibold mb-4">Predeterminados disponibles</h3>
+            <ul className="space-y-4 text-sm max-h-80 overflow-y-auto scroll-smooth">
               {pdvDefaultsList.map((def, idx) => (
-                <li key={idx} className="border-b pb-2">
+                <li key={idx} className="border border-gray-200 rounded-md p-2">
+                  <p className="font-semibold mb-1">{def.autoLabel || `${def.city} – ${def.contactName}`}</p>
                   <p>
                     <span className="font-medium">Nombre de Contacto:</span> {def.contactName || '-'}
                   </p>
@@ -358,15 +340,17 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
                   <div className="flex space-x-2 mt-2">
                     <button
                       onClick={() => handleApplyDefaults(def)}
-                      className="flex-1 bg-green-500 text-white py-1 px-2 rounded-md"
+                      className="flex-1 bg-green-500 text-white py-1 px-2 rounded-md flex items-center justify-center space-x-1"
                     >
-                      Aplicar
+                      <span>✔</span>
+                      <span>Aplicar</span>
                     </button>
                     <button
                       onClick={() => handleDeleteDefaults(idx)}
-                      className="flex-1 bg-red-500 text-white py-1 px-2 rounded-md"
+                      className="flex-1 bg-red-500 text-white py-1 px-2 rounded-md flex items-center justify-center space-x-1"
                     >
-                      Eliminar
+                      <span>🗑</span>
+                      <span>Eliminar</span>
                     </button>
                   </div>
                 </li>
@@ -376,6 +360,50 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
         )}
       </div>
     </div>
+    {showConfirm && (
+      <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-20">
+        <div className="bg-white rounded-lg shadow-lg w-11/12 max-w-md p-4">
+          <h3 className="text-lg font-semibold mb-2">Confirmar cambios</h3>
+          <div className="text-sm space-y-1 max-h-60 overflow-y-auto">
+            <p>
+              <span className="font-medium">Nombre de Contacto:</span> {pdvData.contactName || '-'}
+            </p>
+            <p>
+              <span className="font-medium">Teléfono:</span> {pdvData.contactPhone || '-'}
+            </p>
+            <p>
+              <span className="font-medium">Ciudad:</span> {pdvData.city || '-'}
+            </p>
+            <p>
+              <span className="font-medium">Dirección:</span> {pdvData.address || '-'}
+            </p>
+            <p>
+              <span className="font-medium">Notas:</span> {pdvData.notes || '-'}
+            </p>
+            {pdvData.additionalFields.map((f, i) => (
+              <p key={i}>
+                <span className="font-medium">{f.label}:</span> {f.value || '-'}
+              </p>
+            ))}
+          </div>
+          {saveAsDefault && (
+            <p className="mt-3 text-sm">
+              {defaultAction === 'replace'
+                ? 'Se reemplazará un conjunto de datos predeterminados existente.'
+                : 'Se guardará como nuevo conjunto de datos predeterminados.'}
+            </p>
+          )}
+          <div className="flex justify-end space-x-2 mt-4">
+            <button onClick={() => setShowConfirm(false)} className="bg-gray-300 text-gray-700 py-1 px-3 rounded-md">
+              Revisar otra vez
+            </button>
+            <button onClick={finalizeSubmit} className="bg-tigo-cyan text-white py-1 px-3 rounded-md">
+              Sí, guardar
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
   );
 };
 


### PR DESCRIPTION
## Summary
- replace existing default set when similar to new data
- add confirmation modal before persisting updates
- drop unused `Agregar Campo` logic and button
- enhance default set sidebar visuals and buttons

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688bdd00b9648325be1a59c69276fc66