### PR TITLE
Improve PDV forms and confirmation navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -441,6 +441,8 @@ const App = () => {
             message={confirmationMessage}
             onGoHome={handleGoHome}
             onStayInChannel={() => setCurrentPage('location-select')}
+            onBackToPdv={currentPage === 'confirm-update' ? () => setCurrentPage('update-pdv') : undefined}
+            pdvName={selectedPdvName}
           />
         )}
         </main>

--- a/src/components/ConfirmationMessage.js
+++ b/src/components/ConfirmationMessage.js
@@ -6,7 +6,13 @@ import React from 'react';
  * inicio de la aplicación.
  */
 
-const ConfirmationMessage = ({ message, onGoHome, onStayInChannel }) => {
+const ConfirmationMessage = ({
+  message,
+  onGoHome,
+  onStayInChannel,
+  onBackToPdv,
+  pdvName,
+}) => {
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8 text-center">
       <h2 className="text-3xl font-bold text-green-600 mb-4">¡Éxito!</h2>
@@ -18,6 +24,14 @@ const ConfirmationMessage = ({ message, onGoHome, onStayInChannel }) => {
             className="w-full bg-tigo-cyan text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00a7d6] transition-all"
           >
           Volver al Canal
+          </button>
+        )}
+        {onBackToPdv && (
+          <button
+            onClick={onBackToPdv}
+            className="w-full bg-gray-200 text-gray-800 py-2 px-4 rounded-lg shadow hover:bg-gray-300"
+          >
+            🔁 Volver al PDV: {pdvName}
           </button>
         )}
         <button


### PR DESCRIPTION
## Summary
- avoid duplicate defaults when editing PDVs
- allow starting a new set of PDV data quickly
- add search field for existing PDV defaults
- let confirmation screen return to PDV form

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bebb691a88325aff6ccc926c60832