### PR TITLE
Include PDV snapshot data in exports

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -171,7 +171,13 @@ const App = () => {
   // Confirmación de carrito: aquí se guardan los datos en localStorage.
   // Reemplazar esta lógica por una llamada al backend al integrar APIs.
   const handleConfirmRequest = (requestDetails) => {
-    const requestWithDate = { ...requestDetails, date: new Date().toISOString() };
+    const currentData =
+      getStorageItem(`pdv-${selectedPdvId}-data`) || {};
+    const requestWithDate = {
+      ...requestDetails,
+      pdvData: currentData,
+      date: new Date().toISOString(),
+    };
     // console.log('Solicitud de Material Confirmada:', requestWithDate);
     const existing = getStorageItem('material-requests') || [];
     setStorageItem('material-requests', [...existing, requestWithDate]);

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -76,6 +76,7 @@ const ExportData = ({ onBack, onExport }) => {
         zone: req.zones || [],
         priority: req.priority || '',
         campaigns: req.campaigns || [],
+        pdvData: req.pdvData || getStorageItem(`pdv-${req.pdvId}-data`) || {},
         materials: req.items.map((it) => ({
           id: it.material.id,
           name: it.material.name,

--- a/src/utils/exportToExcel.js
+++ b/src/utils/exportToExcel.js
@@ -19,12 +19,13 @@ export default function exportToExcel(exportObj) {
     const campaigns = Array.isArray(pdv.campaigns)
       ? pdv.campaigns.join(', ')
       : pdv.campaigns || '';
-    const storedData = getStorageItem(`pdv-${pdv.id}-data`) || {};
-    const contactName = storedData.contactName || '-';
-    const contactPhone = storedData.contactPhone || '-';
-    const city = storedData.city || '-';
-    const address = storedData.address || '-';
-    const notes = storedData.notes || '-';
+    const data =
+      pdv.pdvData || getStorageItem(`pdv-${pdv.id}-data`) || {};
+    const contactName = data.contactName || '';
+    const contactPhone = data.contactPhone || '';
+    const city = data.city || '';
+    const address = data.address || '';
+    const notes = data.notes || '';
     pdv.materials.forEach((mat) => {
       rows.push({
         Fecha: exportObj.requestDate,


### PR DESCRIPTION
## Summary
- capture PDV information when a material request is confirmed
- persist that info in each request
- use stored PDV snapshot during Excel export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c03df69f48325abe476141d08f738