### PR TITLE
Add dynamic history view for channels

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -408,7 +408,11 @@ const App = () => {
 
         {/* Formulario para actualizar información del PDV */}
         {isLoggedIn && currentPage === 'update-pdv' && (
-          <PdvUpdateForm selectedPdvId={selectedPdvId} onUpdateConfirm={handleUpdateConfirm} />
+          <PdvUpdateForm
+            selectedPdvId={selectedPdvId}
+            onUpdateConfirm={handleUpdateConfirm}
+            channelId={selectedChannelId}
+          />
         )}
 
         {/* Historial de solicitudes para el PDV */}

--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { getStorageItem } from '../utils/storage';
 import { channels } from '../mock/channels';
 
@@ -11,38 +11,128 @@ import { channels } from '../mock/channels';
  */
 
 const ChannelRequests = ({ channelId, onBack }) => {
-  const requests = getStorageItem('material-requests') || [];
-  const channelRequests = requests.filter((req) => req.channelId === channelId);
+  const materialRequests = getStorageItem('material-requests') || [];
+  const updateRequests = getStorageItem('pdv-update-requests') || [];
+  const channelRequests = materialRequests.filter((req) => req.channelId === channelId);
+  const pdvIds = new Set(channelRequests.map((r) => r.pdvId));
+  const channelUpdates = updateRequests.filter(
+    (u) => u.channelId === channelId || (!u.channelId && pdvIds.has(u.pdvId)),
+  );
   const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
 
+  const [showMaterials, setShowMaterials] = useState(false);
+  const [showUpdates, setShowUpdates] = useState(false);
+  const [expandedMaterials, setExpandedMaterials] = useState({});
+  const [expandedUpdates, setExpandedUpdates] = useState({});
+
+  const toggleMaterialSection = () => setShowMaterials((prev) => !prev);
+  const toggleUpdateSection = () => setShowUpdates((prev) => !prev);
+  const toggleMaterialCard = (idx) =>
+    setExpandedMaterials((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  const toggleUpdateCard = (idx) =>
+    setExpandedUpdates((prev) => ({ ...prev, [idx]: !prev[idx] }));
+
   return (
-    <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8">
+    <div className="relative p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8 pb-24">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">
         Solicitudes para {channelName}
       </h2>
-      {channelRequests.length === 0 ? (
-        <p className="text-gray-600 text-center">No hay solicitudes previas para este canal.</p>
-      ) : (
-        <ul className="space-y-4">
-          {channelRequests.map((req, index) => (
-            <li key={index} className="bg-gray-50 p-3 rounded-lg shadow-sm">
-              <p className="font-semibold text-gray-800">PDV: {req.pdvId}</p>
-              <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
-              <ul className="ml-4 list-disc">
-                {req.items.map((item) => (
-                  <li key={item.id}>
-                    {item.material.name} - {item.measures.name} x {item.quantity}
+
+      {/* Sección Solicitudes de Material */}
+      <div className="mb-4">
+        <button
+          onClick={toggleMaterialSection}
+          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
+        >
+          <span className="font-semibold text-gray-800">Solicitudes de Material</span>
+          <span className="text-xl">{showMaterials ? '−' : '+'}</span>
+        </button>
+        <div className={`overflow-hidden transition-all duration-300 ${showMaterials ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}>
+          {channelRequests.length === 0 ? (
+            <p className="text-gray-600 text-center mt-4">No hay solicitudes previas para este canal.</p>
+          ) : (
+            <ul className="space-y-4 mt-4">
+              {channelRequests.map((req, index) => {
+                const showAll = expandedMaterials[index];
+                const items = showAll ? req.items : req.items.slice(0, 3);
+                return (
+                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
+                    <div className="flex items-center mb-2">
+                      <span className="mr-2 text-xl">📦</span>
+                      <h4 className="font-semibold text-gray-800">PDV: {req.pdvId}</h4>
+                    </div>
+                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
+                    <ul className="ml-6 list-disc">
+                      {items.map((item) => (
+                        <li key={item.id}>
+                          {item.material.name} - {item.measures.name} x {item.quantity}
+                        </li>
+                      ))}
+                    </ul>
+                    {req.items.length > 3 && (
+                      <button onClick={() => toggleMaterialCard(index)} className="text-sm text-tigo-blue mt-2">
+                        {showAll ? 'Ver menos' : 'Ver más'}
+                      </button>
+                    )}
                   </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-      )}
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Sección Actualizaciones de PDV */}
+      <div className="mb-4">
+        <button
+          onClick={toggleUpdateSection}
+          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
+        >
+          <span className="font-semibold text-gray-800">Actualizaciones de PDV</span>
+          <span className="text-xl">{showUpdates ? '−' : '+'}</span>
+        </button>
+        <div className={`overflow-hidden transition-all duration-300 ${showUpdates ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}>
+          {channelUpdates.length === 0 ? (
+            <p className="text-gray-600 text-center mt-4">No hay actualizaciones previas para este canal.</p>
+          ) : (
+            <ul className="space-y-4 mt-4">
+              {channelUpdates.map((update, index) => {
+                const fields = [
+                  { label: 'Nombre de Contacto', value: update.data.contactName },
+                  { label: 'Teléfono', value: update.data.contactPhone },
+                  { label: 'Dirección', value: update.data.address },
+                ];
+                if (update.data.notes) fields.push({ label: 'Notas', value: update.data.notes });
+                const showAllU = expandedUpdates[index];
+                const itemsU = showAllU ? fields : fields.slice(0, 3);
+                return (
+                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
+                    <div className="flex items-center mb-2">
+                      <span className="mr-2 text-xl">📝</span>
+                      <h4 className="font-semibold text-gray-800">PDV: {update.pdvId}</h4>
+                    </div>
+                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(update.date).toLocaleDateString()}</p>
+                    <ul className="ml-6 list-disc">
+                      {itemsU.map((f, idx) => (
+                        <li key={idx}>{f.label}: {f.value}</li>
+                      ))}
+                    </ul>
+                    {fields.length > 3 && (
+                      <button onClick={() => toggleUpdateCard(index)} className="text-sm text-tigo-blue mt-2">
+                        {showAllU ? 'Ver menos' : 'Ver más'}
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
 
       <button
         onClick={onBack}
-        className="w-full mt-6 bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
+        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
       >
         Volver
       </button>

--- a/src/components/PdvUpdateForm.js
+++ b/src/components/PdvUpdateForm.js
@@ -12,7 +12,7 @@ import {
  * las API correspondientes.
  */
 
-const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
+const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm, channelId }) => {
   /* ----------------------------- Estados ----------------------------- */
   // Información editable del PDV
   const [pdvData, setPdvData] = useState({
@@ -226,6 +226,7 @@ const PdvUpdateForm = ({ selectedPdvId, onUpdateConfirm }) => {
     const updates = getStorageItem('pdv-update-requests') || [];
     const updateEntry = {
       pdvId: selectedPdvId,
+      channelId,
       data: pdvData,
       date: new Date().toISOString(),
     };


### PR DESCRIPTION
## Summary
- show channel requests with collapsible sections like PDV history
- keep PDV info and allow expanding cards
- store channelId in PDV update entries
- pass channelId to update form

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c19ebecec832594e99254c08be4dd