### PR TITLE
Improve material names display

### DIFF
--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { getStorageItem } from '../utils/storage';
 import { channels } from '../mock/channels';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 /**
  * Lista de solicitudes realizadas por canal.
@@ -65,7 +66,7 @@ const ChannelRequests = ({ channelId, onBack }) => {
                     <ul className="ml-6 list-disc">
                       {items.map((item) => (
                         <li key={item.id}>
-                          {item.material.name} - {item.measures.name} x {item.quantity}
+                          {getDisplayName(item.material.name)} - {item.measures.name} ({formatQuantity(item.material.name, item.quantity)})
                         </li>
                       ))}
                     </ul>

--- a/src/components/CreateCampaignForm.js
+++ b/src/components/CreateCampaignForm.js
@@ -4,6 +4,7 @@ import { channels } from '../mock/channels';
 import { materials } from '../mock/materials';
 import { channelMaterials } from '../mock/channelMaterials';
 import MaterialSelectorModal from './MaterialSelectorModal';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 /**
  * Formulario para crear una campaña nueva.
@@ -178,10 +179,10 @@ const CreateCampaignForm = ({ onBack }) => {
               );
               return (
                 <li key={id} className="mb-2">
-                  {mat?.name || id}{' '}
+                  {getDisplayName(mat?.name || id)}{' '}
                   {mat?.requiresCotizacion &&
                     '(Cotizable – sin stock predeterminado) '}
-                  ({mat?.channels ? mat.channels.join(', ') : ''}) - {data.quantity}
+                  ({mat?.channels ? mat.channels.join(', ') : ''}) - {formatQuantity(mat?.name || id, data.quantity)}
                   <select
                     className="mt-1 w-full bg-gray-100 border border-gray-300 py-1 px-2 rounded"
                     value={data.measure}

--- a/src/components/MaterialRequestForm.js
+++ b/src/components/MaterialRequestForm.js
@@ -6,6 +6,7 @@ import { channelMaterials } from '../mock/channelMaterials';
 import ContextInfo from './ContextInfo';
 import SingleSelectModal from './SingleSelectModal';
 import PreviousCampaignsModal from './PreviousCampaignsModal';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 
 
@@ -218,7 +219,9 @@ const MaterialRequestForm = ({
             className="w-full bg-gray-100 border border-gray-300 py-2 px-3 rounded-lg text-left"
           >
             {selectedMaterial
-              ? materials.find((m) => m.id === selectedMaterial)?.name
+              ? getDisplayName(
+                  materials.find((m) => m.id === selectedMaterial)?.name,
+                )
               : 'Seleccionar material'}
           </button>
           {selectedMaterial && (
@@ -334,13 +337,13 @@ const MaterialRequestForm = ({
               >
                 <div>
                   <p className="font-semibold text-gray-800">
-                    {item.material.name}
+                    {getDisplayName(item.material.name)}
                   </p>
                   <p className="text-sm text-gray-600">
                     Medidas: {item.measures.name}
                   </p>
                   <p className="text-sm text-gray-600">
-                    Cantidad: {item.quantity}
+                    Cantidad: {formatQuantity(item.material.name, item.quantity)}
                   </p>
                 </div>
                 <button
@@ -481,9 +484,9 @@ const MaterialRequestForm = ({
               <p className="font-medium mt-2">Materiales:</p>
               {cart.map((item) => (
                 <div key={item.id} className="border-t pt-1 mt-1">
-                  <p>{item.material.name}</p>
+                  <p>{getDisplayName(item.material.name)}</p>
                   <p className="text-xs">Medidas: {item.measures.name}</p>
-                  <p className="text-xs">Cantidad: {item.quantity}</p>
+                  <p className="text-xs">Cantidad: {formatQuantity(item.material.name, item.quantity)}</p>
                   {item.notes && (
                     <p className="text-xs">Notas: {item.notes}</p>
                   )}

--- a/src/components/MaterialSelectorModal.js
+++ b/src/components/MaterialSelectorModal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 /**
  * Modal para seleccionar materiales de forma cómoda.
@@ -40,7 +41,7 @@ const MaterialSelectorModal = ({
                     disabled={m.stock === 0 && !m.requiresCotizacion}
                     onChange={() => onToggle(m.id, m.stock)}
                   />
-                  {m.name}{' '}
+                  {getDisplayName(m.name)}{' '}
                   {m.requiresCotizacion && (
                     <span className="text-xs text-gray-500">(Cotizable – sin stock predeterminado)</span>
                   )}{' '}

--- a/src/components/PreviousCampaignsModal.js
+++ b/src/components/PreviousCampaignsModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { getStorageItem } from '../utils/storage';
 import { campaigns as defaultCampaigns } from '../mock/campaigns';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 const PreviousCampaignsModal = ({ pdvId, onSelect, onClose }) => {
   const [search, setSearch] = useState('');
@@ -42,7 +43,7 @@ const PreviousCampaignsModal = ({ pdvId, onSelect, onClose }) => {
               <ul className="ml-4 list-disc text-sm">
                 {req.items.map((it) => (
                   <li key={it.id}>
-                    {it.material.name} - {it.measures.name} x {it.quantity}
+                    {getDisplayName(it.material.name)} - {it.measures.name} ({formatQuantity(it.material.name, it.quantity)})
                   </li>
                 ))}
               </ul>

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { getStorageItem } from '../utils/storage';
+import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
 /**
  * Muestra el historial de solicitudes de material y actualizaciones
@@ -59,7 +60,7 @@ const PreviousRequests = ({ pdvId, onBack }) => {
                     <ul className="ml-6 list-disc">
                       {items.map((item) => (
                         <li key={item.id}>
-                          {item.material.name} - {item.measures.name} x {item.quantity}
+                          {getDisplayName(item.material.name)} - {item.measures.name} ({formatQuantity(item.material.name, item.quantity)})
                         </li>
                       ))}
                     </ul>

--- a/src/components/SingleSelectModal.js
+++ b/src/components/SingleSelectModal.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getDisplayName } from '../utils/materialDisplay';
 
 const SingleSelectModal = ({
   title = '',
@@ -34,7 +35,7 @@ const SingleSelectModal = ({
                 checked={selectedId === it.id}
                 onChange={() => onSelect(it.id)}
               />
-              {it.name}
+              {getDisplayName(it.name)}
             </label>
           ))}
         {items.filter((it) => it.name.toLowerCase().includes(search.toLowerCase())).length === 0 && (

--- a/src/utils/materialDisplay.js
+++ b/src/utils/materialDisplay.js
@@ -1,0 +1,15 @@
+export const getDisplayName = (name = '') => {
+  const trimmed = name.trim();
+  const lower = trimmed.toLowerCase();
+  if (lower.includes('tend card') || lower.includes('nps')) {
+    return `Puesto de asesores (${trimmed})`;
+  }
+  return trimmed;
+};
+
+export const formatQuantity = (name = '', quantity) => {
+  if (name.toLowerCase().includes('volantes')) {
+    return `${quantity} asesores`;
+  }
+  return quantity;
+};


### PR DESCRIPTION
## Summary
- add `materialDisplay` utils
- update request forms and listings to show custom material names
- show advisor counts for 'volantes' materials

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c42a4e8ec83259e2492cb1a72ead5