### PR TITLE
Handle display for 'volantes' materials

### DIFF
--- a/src/utils/exportToExcel.js
+++ b/src/utils/exportToExcel.js
@@ -1,5 +1,6 @@
 import * as XLSX from 'xlsx';
 import { getStorageItem } from './storage';
+import { getDisplayName, formatQuantity } from './materialDisplay';
 
 /**
  * Exporta un objeto de solicitud de materiales a un archivo Excel (.xlsx).
@@ -39,8 +40,8 @@ export default function exportToExcel(exportObj) {
         Ciudad: city,
         Dirección: address,
         'Notas internas': notes,
-        Material: mat.name,
-        Cantidad: mat.quantity || '',
+        Material: getDisplayName(mat.name),
+        Cantidad: formatQuantity(mat.name, mat.quantity) || '',
         Medida: mat.measure || '',
         '¿Cotizable?': mat.requiresCotizacion ? 'Sí' : 'No',
         Zona: zone,

--- a/src/utils/materialDisplay.js
+++ b/src/utils/materialDisplay.js
@@ -4,6 +4,9 @@ export const getDisplayName = (name = '') => {
   if (lower.includes('tend card') || lower.includes('nps')) {
     return `Puesto de asesores (${trimmed})`;
   }
+  if (lower.includes('volantes')) {
+    return `Cantidad de asesores (${trimmed})`;
+  }
   return trimmed;
 };
 


### PR DESCRIPTION
## Summary
- show `Cantidad de asesores` for materials containing `volantes`
- export formatted names and quantities to Excel

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688c48a8707c8325b08a1d6d9ead138a