### PR TITLE
Normalize location dataset and validate PDVs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,7 +61,10 @@ const App = () => {
 
   // Limpieza inicial de localStorage para remover datos obsoletos
   useEffect(() => {
-    const validIds = Object.values(pdvs).flat().map((p) => p.id);
+    const validIds = Object.values(pdvs)
+      .flat()
+      .filter((p) => p.complete)
+      .map((p) => p.id);
     cleanupLocalStorage(validIds);
   }, []);
 

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -78,11 +78,17 @@ const ExportData = ({ onBack, onExport }) => {
     if (!selectedRegion) return [];
     if (selectedPdv) return [selectedPdv];
     if (selectedSubterritory) {
-      return (pdvs[selectedSubterritory] || []).map((p) => p.id);
+      return (pdvs[selectedSubterritory] || [])
+        .filter((p) => p.complete)
+        .map((p) => p.id);
     }
     let ids = [];
     (subterritories[selectedRegion] || []).forEach((sub) => {
-      ids = ids.concat((pdvs[sub.id] || []).map((p) => p.id));
+      ids = ids.concat(
+        (pdvs[sub.id] || [])
+          .filter((p) => p.complete)
+          .map((p) => p.id),
+      );
     });
     return ids;
   };
@@ -192,11 +198,13 @@ const ExportData = ({ onBack, onExport }) => {
                   className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
                 >
                   <option value="">Todos</option>
-                  {(pdvs[selectedSubterritory] || []).map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
+                  {(pdvs[selectedSubterritory] || [])
+                    .filter((p) => p.complete)
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                      </option>
+                    ))}
                 </select>
               </div>
             )}

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -32,7 +32,9 @@ const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
   // Cada vez que cambia el subterritorio se filtran los PDV
   useEffect(() => {
     if (selectedSubterritory) {
-      setAvailablePdvs(pdvs[selectedSubterritory] || []);
+      const list = pdvs[selectedSubterritory] || [];
+      // Mostrar únicamente PDVs completos
+      setAvailablePdvs(list.filter((p) => p.complete));
       setSearchTerm('');
     } else {
       setAvailablePdvs([]);

--- a/src/mock/locations.js
+++ b/src/mock/locations.js
@@ -1,11 +1,15 @@
-export const regions = [
+import normalizeLocationData, { validateNewPdv } from '../utils/locationNormalizer';
+
+// Raw region list intentionally missing some entries to test normalization
+const rawRegions = [
   { id: 'region-bogota', name: 'Bogotá' },
-  { id: 'region-sur', name: 'Región Sur' },
-  { id: 'region-costa', name: 'Región Costa' },
-  { id: 'region-andina', name: 'Andina' },
+  { id: 'region-sur', name: 'región sur' },
+  { id: 'region-costa', name: 'REGIÓN COSTA' },
+  { id: 'region-andina', name: 'andina' },
 ];
 
-export const subterritories = {
+// Mapping of region -> subterritories
+const rawSubterritories = {
   'region-bogota': [
     { id: 'sub-bogota-1', name: 'Bogotá Zona 1' },
     { id: 'sub-bogota-2', name: 'Bogotá Zona 2' },
@@ -14,6 +18,7 @@ export const subterritories = {
     { id: 'sub-sur-1', name: 'Subterritorio Sur 1' },
     { id: 'sub-sur-2', name: 'Subterritorio Sur 2' },
   ],
+  // Región Centro no estaba listada en rawRegions
   'region-centro': [
     { id: 'sub-centro-1', name: 'Subterritorio Centro 1' },
     { id: 'sub-centro-2', name: 'Subterritorio Centro 2' },
@@ -25,7 +30,9 @@ export const subterritories = {
   ],
 };
 
-export const pdvs = {
+// PDVs grouped by subterritory. Many IDs are duplicated intentionally to test
+// the normalization process which assigns unique IDs.
+const rawPdvs = {
   'sub-bogota-1': [
     { id: 'pdv-b1-001', name: 'PDV Bogotá 1 - 001' },
     { id: 'pdv-b1-002', name: 'PDV Bogotá 1 - 002' },
@@ -100,3 +107,12 @@ export const pdvs = {
     { id: 'pdv-11', name: 'ORIENTE PAP EFICACIA 4' },
   ],
 };
+
+// Perform normalization to clean and enrich the data structures
+const { regions, subterritories, pdvs } = normalizeLocationData(
+  rawRegions,
+  rawSubterritories,
+  rawPdvs,
+);
+
+export { regions, subterritories, pdvs, validateNewPdv };

--- a/src/utils/locationNormalizer.js
+++ b/src/utils/locationNormalizer.js
@@ -1,0 +1,121 @@
+/**
+ * Utilities for normalizing and validating location data.
+ *
+ * The normalization process cleans region and subterritory names,
+ * ensures all referenced regions exist, and fixes duplicated PDV IDs.
+ * Each PDV is enriched with region and subterritory references and
+ * basic contact information.
+ */
+
+// Helper to capitalize every word and trim spacing
+const normalizeName = (str = '') =>
+  str
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
+/**
+ * Normalizes location structures.
+ *
+ * @param {Array} regionList - array of region objects
+ * @param {Object} subMap - mapping regionId -> array of subterritories
+ * @param {Object} pdvMap - mapping subterritoryId -> array of PDVs
+ * @returns {{regions: Array, subterritories: Object, pdvs: Object}}
+ */
+export const normalizeLocationData = (
+  regionList = [],
+  subMap = {},
+  pdvMap = {},
+) => {
+  const regionMap = new Map();
+  regionList.forEach((r) => {
+    if (r && r.id) {
+      regionMap.set(r.id.trim(), {
+        id: r.id.trim(),
+        name: normalizeName(r.name || r.id),
+      });
+    }
+  });
+
+  // Ensure all regions referenced in subterritories exist
+  Object.keys(subMap).forEach((regionId) => {
+    if (!regionMap.has(regionId)) {
+      const name = normalizeName(regionId.replace('region-', '').replace('-', ' '));
+      regionMap.set(regionId, { id: regionId, name });
+    }
+  });
+
+  // Normalize subterritory names
+  const normalizedSubs = {};
+  Object.entries(subMap).forEach(([regionId, subs]) => {
+    normalizedSubs[regionId] = subs.map((s) => ({
+      id: s.id.trim(),
+      name: normalizeName(s.name || s.id),
+    }));
+  });
+
+  // Map subterritory -> region for quick lookup
+  const subToRegion = {};
+  Object.entries(normalizedSubs).forEach(([regionId, subs]) => {
+    subs.forEach((s) => {
+      subToRegion[s.id] = regionId;
+    });
+  });
+
+  // Normalize PDVs, ensuring unique IDs and required fields
+  const seenIds = new Set();
+  const normalizedPdvs = {};
+  Object.entries(pdvMap).forEach(([subId, list]) => {
+    normalizedPdvs[subId] = list.map((pdv, idx) => {
+      let id = pdv.id ? pdv.id.trim() : '';
+      if (!id || seenIds.has(id)) {
+        id = `${subId}-${idx + 1}`;
+      }
+      // Avoid collisions
+      while (seenIds.has(id)) {
+        id = `${id}-${idx + 1}`;
+      }
+      seenIds.add(id);
+
+      const regionId = subToRegion[subId] || '';
+      const address = pdv.address || 'Sin dirección';
+      const contact = pdv.contact || 'Sin contacto';
+      const complete = Boolean(
+        id && pdv.name && regionId && subId && address && contact,
+      );
+      return {
+        id,
+        name: normalizeName(pdv.name || id),
+        regionId,
+        subterritoryId: subId,
+        address,
+        contact,
+        complete,
+      };
+    });
+  });
+
+  return {
+    regions: Array.from(regionMap.values()),
+    subterritories: normalizedSubs,
+    pdvs: normalizedPdvs,
+  };
+};
+
+/**
+ * Validates a new PDV before insertion.
+ * Ensures required fields exist and ID is unique.
+ *
+ * @param {Object} pdv - PDV data to validate
+ * @param {Object} pdvData - existing PDV mapping
+ * @returns {boolean}
+ */
+export const validateNewPdv = (pdv, pdvData) => {
+  const required = ['id', 'name', 'regionId', 'subterritoryId', 'address', 'contact'];
+  if (!pdv || !required.every((k) => pdv[k])) return false;
+  const allPdvs = Object.values(pdvData || {}).flat();
+  return !allPdvs.some((p) => p.id === pdv.id);
+};
+
+export default normalizeLocationData;


### PR DESCRIPTION
## Summary
- add utility to normalize regions, subterritories and PDVs
- ensure all regions exist and PDV IDs are unique
- hide incomplete PDVs in selectors and localStorage cleanup

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c12be91fc8325b0897c1e61d57266