### PR TITLE
Add PDV snapshot and navigation to material requests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,17 +145,14 @@ const App = () => {
   // Confirmación de carrito: aquí se guardan los datos en localStorage.
   // Reemplazar esta lógica por una llamada al backend al integrar APIs.
   const handleConfirmRequest = (requestDetails) => {
-    const currentData =
-      getStorageItem(`pdv-${selectedPdvId}-data`) || {};
     const requestWithDate = {
       ...requestDetails,
-      pdvData: currentData,
+      pdvData: requestDetails.pdvSnapshot,
       date: new Date().toISOString(),
     };
-    // console.log('Solicitud de Material Confirmada:', requestWithDate);
     const existing = getStorageItem('material-requests') || [];
     setStorageItem('material-requests', [...existing, requestWithDate]);
-    setConfirmationMessage('¡Tu solicitud de material ha sido enviada con éxito!');
+    setConfirmationMessage(`Solicitud registrada para ${selectedPdvName}`);
     setCurrentPage('confirm-request');
   };
 
@@ -371,6 +368,7 @@ const App = () => {
         {isLoggedIn && currentPage === 'request-material' && (
           <MaterialRequestForm
             onConfirmRequest={handleConfirmRequest}
+            onBackToPdv={() => setCurrentPage('pdv-actions')}
             selectedPdvId={selectedPdvId}
             selectedPdvName={selectedPdvName}
             selectedRegionName={selectedRegionName}
@@ -425,13 +423,7 @@ const App = () => {
             message={confirmationMessage}
             onGoHome={handleGoHome}
             onStayInChannel={() => setCurrentPage('location-select')}
-            onBackToPdv={
-              currentPage === 'confirm-update'
-                ? () => setCurrentPage('update-pdv')
-                : currentPage === 'confirm-request'
-                ? () => setCurrentPage('request-material')
-                : undefined
-            }
+            onBackToPdv={() => setCurrentPage('pdv-actions')}
             pdvName={selectedPdvName}
           />
         )}

--- a/src/components/ConfirmationMessage.js
+++ b/src/components/ConfirmationMessage.js
@@ -27,15 +27,12 @@ const ConfirmationMessage = ({
           </button>
         )}
         {onBackToPdv && (
-          <div>
-            <button
-              onClick={onBackToPdv}
-              className="w-full bg-gray-200 text-gray-800 py-2 px-4 rounded-lg shadow hover:bg-gray-300"
-            >
-              Volver al PDV actual
-            </button>
-            <p className="mt-1 text-sm text-gray-600">{pdvName}</p>
-          </div>
+          <button
+            onClick={onBackToPdv}
+            className="w-full bg-gray-200 text-gray-800 py-2 px-4 rounded-lg shadow hover:bg-gray-300"
+          >
+            Volver al PDV {pdvName}
+          </button>
         )}
         <button
           onClick={onGoHome}

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -46,26 +46,34 @@ const ExportData = ({ onBack, onExport }) => {
   const buildExportObject = (requests, scope) => {
     return {
       scope,
-      pdvs: requests.map((req) => ({
-        ...getPdvInfo(req.pdvId),
-        channelId: req.channelId,
-        channelName:
-          channels.find((c) => c.id === req.channelId)?.name || req.channelId,
-        date: req.date || new Date().toISOString(),
-        requestType: 'Solicitud',
-        zone: req.zones || [],
-        priority: req.priority || '',
-        campaigns: req.campaigns || [],
-        pdvData: req.pdvData || getStorageItem(`pdv-${req.pdvId}-data`) || {},
-        materials: (req.items || []).map((it) => ({
-          id: it.material.id,
-          name: it.material.name,
-          quantity: it.quantity,
-          measure: it.measures.name,
-          requiresCotizacion: it.material.requiresCotizacion,
-          observations: it.notes || '',
-        })),
-      })),
+      pdvs: requests.map((req) => {
+        const info = getPdvInfo(req.pdvId);
+        return {
+          ...info,
+          regionName: req.region || info.regionName,
+          subterritoryName: req.subterritory || info.subterritoryName,
+          channelId: req.channelId,
+          channelName:
+            channels.find((c) => c.id === req.channelId)?.name || req.channelId,
+          date: req.date || new Date().toISOString(),
+          requestType: 'Solicitud',
+          zone: req.zones || [],
+          priority: req.priority || '',
+          campaigns: req.campaigns || [],
+          pdvData:
+            req.pdvSnapshot ||
+            req.pdvData ||
+            getStorageItem(`pdv-${req.pdvId}-data`) || {},
+          materials: (req.items || []).map((it) => ({
+            id: it.material.id,
+            name: it.material.name,
+            quantity: it.quantity,
+            measure: it.measures.name,
+            requiresCotizacion: it.material.requiresCotizacion,
+            observations: it.notes || '',
+          })),
+        };
+      }),
     };
   };
 


### PR DESCRIPTION
## Summary
- enforce required fields before confirming material requests
- capture PDV snapshot and show full summary modal with return to PDV option
- persist requests with PDV details and expose return-to-PDV in confirmation message
- include PDV snapshot on data exports

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)

------
https://chatgpt.com/codex/tasks/task_e_689c21bc3dc48325866aadc3366fbafa