### PR TITLE
feat: unify PDV and channel history in reusable list

### DIFF
--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -1,143 +1,34 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { getStorageItem } from '../utils/storage';
+import HistoryList from './history/HistoryList';
+import { adaptMaterialRequests, adaptPdvUpdates, buildPdvIdMap } from '../utils/historyAdapter';
+import { regions, subterritories, pdvs } from '../mock/locations';
 import { channels } from '../mock/channels';
-import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
-/**
- * Lista de solicitudes realizadas por canal.
- *
- * Los datos provienen de localStorage como ejemplo. Para la
- * integración real se deberá consultar el backend y obtener la
- * información filtrada por `channelId`.
- */
+const idMap = buildPdvIdMap(pdvs, regions, subterritories);
 
 const ChannelRequests = ({ channelId, onBack }) => {
-  const materialRequests = getStorageItem('material-requests') || [];
-  const updateRequests = getStorageItem('pdv-update-requests') || [];
-  const channelRequests = materialRequests.filter((req) => req.channelId === channelId);
-  const pdvIds = new Set(channelRequests.map((r) => r.pdvId));
-  const channelUpdates = updateRequests.filter(
-    (u) => u.channelId === channelId || (!u.channelId && pdvIds.has(u.pdvId)),
+  const materialRequests = (getStorageItem('material-requests') || []).filter(
+    (req) => req.channelId === channelId,
   );
+  const pdvIds = new Set(materialRequests.map((r) => r.pdvId));
+  const updateRequests = (getStorageItem('pdv-update-requests') || []).filter(
+    (u) => u.channelId === channelId || pdvIds.has(u.pdvId),
+  );
+
+  const requests = adaptMaterialRequests(materialRequests, { idMap });
+  const updates = adaptPdvUpdates(updateRequests, { idMap });
   const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
 
-  const [showMaterials, setShowMaterials] = useState(false);
-  const [showUpdates, setShowUpdates] = useState(false);
-  const [expandedMaterials, setExpandedMaterials] = useState({});
-  const [expandedUpdates, setExpandedUpdates] = useState({});
-
-  const toggleMaterialSection = () => setShowMaterials((prev) => !prev);
-  const toggleUpdateSection = () => setShowUpdates((prev) => !prev);
-  const toggleMaterialCard = (idx) =>
-    setExpandedMaterials((prev) => ({ ...prev, [idx]: !prev[idx] }));
-  const toggleUpdateCard = (idx) =>
-    setExpandedUpdates((prev) => ({ ...prev, [idx]: !prev[idx] }));
-
   return (
-    <div className="relative p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8 pb-24">
-      <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">
-        Solicitudes para {channelName}
-      </h2>
-
-      {/* Sección Solicitudes de Material */}
-      <div className="mb-4">
-        <button
-          onClick={toggleMaterialSection}
-          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
-        >
-          <span className="font-semibold text-gray-800">Solicitudes de Material</span>
-          <span className="text-xl">{showMaterials ? '−' : '+'}</span>
-        </button>
-        <div className={`overflow-hidden transition-all duration-300 ${showMaterials ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}>
-          {channelRequests.length === 0 ? (
-            <p className="text-gray-600 text-center mt-4">No hay solicitudes previas para este canal.</p>
-          ) : (
-            <ul className="space-y-4 mt-4">
-              {channelRequests.map((req, index) => {
-                const showAll = expandedMaterials[index];
-                const items = showAll ? req.items : req.items.slice(0, 3);
-                return (
-                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
-                    <div className="flex items-center mb-2">
-                      <span className="mr-2 text-xl">📦</span>
-                      <h4 className="font-semibold text-gray-800">PDV: {req.pdvId}</h4>
-                    </div>
-                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
-                    <ul className="ml-6 list-disc">
-                      {items.map((item) => (
-                        <li key={item.id}>
-                          {getDisplayName(item.material.name)} - {item.measures.name} ({formatQuantity(item.material.name, item.quantity)})
-                        </li>
-                      ))}
-                    </ul>
-                    {req.items.length > 3 && (
-                      <button onClick={() => toggleMaterialCard(index)} className="text-sm text-tigo-blue mt-2">
-                        {showAll ? 'Ver menos' : 'Ver más'}
-                      </button>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      {/* Sección Actualizaciones de PDV */}
-      <div className="mb-4">
-        <button
-          onClick={toggleUpdateSection}
-          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
-        >
-          <span className="font-semibold text-gray-800">Actualizaciones de PDV</span>
-          <span className="text-xl">{showUpdates ? '−' : '+'}</span>
-        </button>
-        <div className={`overflow-hidden transition-all duration-300 ${showUpdates ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}>
-          {channelUpdates.length === 0 ? (
-            <p className="text-gray-600 text-center mt-4">No hay actualizaciones previas para este canal.</p>
-          ) : (
-            <ul className="space-y-4 mt-4">
-              {channelUpdates.map((update, index) => {
-                const fields = [
-                  { label: 'Nombre de Contacto', value: update.data.contactName },
-                  { label: 'Teléfono', value: update.data.contactPhone },
-                  { label: 'Dirección', value: update.data.address },
-                ];
-                if (update.data.notes) fields.push({ label: 'Notas', value: update.data.notes });
-                const showAllU = expandedUpdates[index];
-                const itemsU = showAllU ? fields : fields.slice(0, 3);
-                return (
-                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
-                    <div className="flex items-center mb-2">
-                      <span className="mr-2 text-xl">📝</span>
-                      <h4 className="font-semibold text-gray-800">PDV: {update.pdvId}</h4>
-                    </div>
-                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(update.date).toLocaleDateString()}</p>
-                    <ul className="ml-6 list-disc">
-                      {itemsU.map((f, idx) => (
-                        <li key={idx}>{f.label}: {f.value}</li>
-                      ))}
-                    </ul>
-                    {fields.length > 3 && (
-                      <button onClick={() => toggleUpdateCard(index)} className="text-sm text-tigo-blue mt-2">
-                        {showAllU ? 'Ver menos' : 'Ver más'}
-                      </button>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      <button
-        onClick={onBack}
-        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
-      >
-        Volver
-      </button>
-    </div>
+    <HistoryList
+      scope="canal"
+      title={`Solicitudes para ${channelName}`}
+      requests={requests}
+      updates={updates}
+      onBack={onBack}
+      context={{ canal: channelName }}
+    />
   );
 };
 

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -1,137 +1,37 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { getStorageItem } from '../utils/storage';
-import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
+import HistoryList from './history/HistoryList';
+import { adaptMaterialRequests, adaptPdvUpdates, buildPdvIdMap } from '../utils/historyAdapter';
+import { regions, subterritories, pdvs } from '../mock/locations';
 
-/**
- * Muestra el historial de solicitudes de material y actualizaciones
- * guardadas en localStorage para un PDV concreto.
- *
- * Al conectar con el backend, se debería reemplazar la lectura de
- * localStorage por peticiones a la API.
- */
+const idMap = buildPdvIdMap(pdvs, regions, subterritories);
 
-// `pdvId` identifica el punto de venta y `onBack` vuelve a la pantalla anterior
 const PreviousRequests = ({ pdvId, onBack }) => {
-  const materialRequests = getStorageItem('material-requests') || [];
-  const updateRequests = getStorageItem('pdv-update-requests') || [];
-  const pdvRequests = materialRequests.filter((req) => req.pdvId === pdvId);
-  const pdvUpdates = updateRequests.filter((req) => req.pdvId === pdvId);
+  const materialRequests = (getStorageItem('material-requests') || []).filter(
+    (req) => req.pdvId === pdvId,
+  );
+  const updateRequests = (getStorageItem('pdv-update-requests') || []).filter(
+    (req) => req.pdvId === pdvId,
+  );
 
-  const [showMaterials, setShowMaterials] = useState(false);
-  const [showUpdates, setShowUpdates] = useState(false);
-  const [expandedMaterials, setExpandedMaterials] = useState({});
-  const [expandedUpdates, setExpandedUpdates] = useState({});
-
-  const toggleMaterialSection = () => setShowMaterials((prev) => !prev);
-  const toggleUpdateSection = () => setShowUpdates((prev) => !prev);
-  const toggleMaterialCard = (idx) =>
-    setExpandedMaterials((prev) => ({ ...prev, [idx]: !prev[idx] }));
-  const toggleUpdateCard = (idx) =>
-    setExpandedUpdates((prev) => ({ ...prev, [idx]: !prev[idx] }));
+  const requests = adaptMaterialRequests(materialRequests, { idMap });
+  const updates = adaptPdvUpdates(updateRequests, { idMap });
+  const info = idMap[pdvId] || {};
 
   return (
-    <div className="relative p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8 pb-24">
-      <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Solicitudes Anteriores</h2>
-
-      {/* Sección Solicitudes de Material */}
-      <div className="mb-4">
-        <button
-          onClick={toggleMaterialSection}
-          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
-        >
-          <span className="font-semibold text-gray-800">Solicitudes de Material</span>
-          <span className="text-xl">{showMaterials ? '−' : '+'}</span>
-        </button>
-        <div className={`overflow-hidden transition-all duration-300 ${showMaterials ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}> 
-          {pdvRequests.length === 0 ? (
-            <p className="text-gray-600 text-center mt-4">No hay solicitudes previas para este PDV.</p>
-          ) : (
-            <ul className="space-y-4 mt-4">
-              {pdvRequests.map((req, index) => {
-                const showAll = expandedMaterials[index];
-                const items = showAll ? req.items : req.items.slice(0, 3);
-                return (
-                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
-                    <div className="flex items-center mb-2">
-                      <span className="mr-2 text-xl">📦</span>
-                      <h4 className="font-semibold text-gray-800">Solicitud #{index + 1}</h4>
-                    </div>
-                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(req.date).toLocaleDateString()}</p>
-                    <ul className="ml-6 list-disc">
-                      {items.map((item) => (
-                        <li key={item.id}>
-                          {getDisplayName(item.material.name)} - {item.measures.name} ({formatQuantity(item.material.name, item.quantity)})
-                        </li>
-                      ))}
-                    </ul>
-                    {req.items.length > 3 && (
-                      <button onClick={() => toggleMaterialCard(index)} className="text-sm text-tigo-blue mt-2">
-                        {showAll ? 'Ver menos' : 'Ver más'}
-                      </button>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      {/* Sección Actualizaciones de PDV */}
-      <div className="mb-4">
-        <button
-          onClick={toggleUpdateSection}
-          className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
-        >
-          <span className="font-semibold text-gray-800">Actualizaciones de PDV</span>
-          <span className="text-xl">{showUpdates ? '−' : '+'}</span>
-        </button>
-        <div className={`overflow-hidden transition-all duration-300 ${showUpdates ? 'max-h-[1000px] mt-3' : 'max-h-0'}`}> 
-          {pdvUpdates.length === 0 ? (
-            <p className="text-gray-600 text-center mt-4">No hay actualizaciones previas para este PDV.</p>
-          ) : (
-            <ul className="space-y-4 mt-4">
-              {pdvUpdates.map((update, index) => {
-                const fields = [
-                  { label: 'Nombre de Contacto', value: update.data.contactName },
-                  { label: 'Teléfono', value: update.data.contactPhone },
-                  { label: 'Dirección', value: update.data.address },
-                ];
-                if (update.data.notes) fields.push({ label: 'Notas', value: update.data.notes });
-                const showAllU = expandedUpdates[index];
-                const itemsU = showAllU ? fields : fields.slice(0, 3);
-                return (
-                  <li key={index} className="bg-gray-50 p-4 rounded-lg shadow">
-                    <div className="flex items-center mb-2">
-                      <span className="mr-2 text-xl">📝</span>
-                      <h4 className="font-semibold text-gray-800">Actualización #{index + 1}</h4>
-                    </div>
-                    <p className="text-sm text-gray-600 mb-2">Fecha: {new Date(update.date).toLocaleDateString()}</p>
-                    <ul className="ml-6 list-disc">
-                      {itemsU.map((f, idx) => (
-                        <li key={idx}>{f.label}: {f.value}</li>
-                      ))}
-                    </ul>
-                    {fields.length > 3 && (
-                      <button onClick={() => toggleUpdateCard(index)} className="text-sm text-tigo-blue mt-2">
-                        {showAllU ? 'Ver menos' : 'Ver más'}
-                      </button>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      <button
-        onClick={onBack}
-        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
-      >
-        Volver
-      </button>
-    </div>
+    <HistoryList
+      scope="pdv"
+      title="Solicitudes del PDV"
+      requests={requests}
+      updates={updates}
+      onBack={onBack}
+      context={{
+        pdvId,
+        pdvName: info.pdvName,
+        region: info.region,
+        subterritory: info.subterritory,
+      }}
+    />
   );
 };
 

--- a/src/components/history/HistoryList.jsx
+++ b/src/components/history/HistoryList.jsx
@@ -1,0 +1,241 @@
+import React, { useState, useMemo } from 'react';
+import { formatQuantity } from '../../utils/materialDisplay';
+
+const HistoryList = ({
+  scope = 'pdv',
+  title = 'Historial',
+  requests = [],
+  updates = [],
+  onBack,
+  context = {},
+}) => {
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [search, setSearch] = useState('');
+  const [showReqSection, setShowReqSection] = useState(false);
+  const [showUpdSection, setShowUpdSection] = useState(false);
+  const [expandedReqs, setExpandedReqs] = useState({});
+  const [expandedUpds, setExpandedUpds] = useState({});
+
+  const matchesSearch = (text = '') =>
+    text.toLowerCase().includes(search.toLowerCase());
+
+  const filterList = (list, kind) => {
+    return list.filter((entry) => {
+      if (fromDate && new Date(entry.date) < new Date(fromDate)) return false;
+      if (toDate && new Date(entry.date) > new Date(toDate)) return false;
+      if (search) {
+        if (kind === 'request') {
+          const inPdv = matchesSearch(entry.pdvName || entry.pdvId);
+          const inCampaign = entry.campaign && matchesSearch(entry.campaign);
+          const inNotes = entry.pdvSnapshot && matchesSearch(entry.pdvSnapshot.notes || '');
+          const inItems = entry.items.some(
+            (it) => matchesSearch(it.displayName) || matchesSearch(it.rawName),
+          );
+          if (!(inPdv || inCampaign || inNotes || inItems)) return false;
+        } else {
+          const inPdv = matchesSearch(entry.pdvName || entry.pdvId);
+          const inNotes = matchesSearch(entry.data.notes || '');
+          if (!(inPdv || inNotes)) return false;
+        }
+      }
+      return true;
+    });
+  };
+
+  const filteredRequests = useMemo(() => {
+    if (typeFilter === 'updates') return [];
+    return filterList(requests, 'request');
+  }, [requests, typeFilter, fromDate, toDate, search]);
+
+  const filteredUpdates = useMemo(() => {
+    if (typeFilter === 'material') return [];
+    return filterList(updates, 'update');
+  }, [updates, typeFilter, fromDate, toDate, search]);
+
+  const toggleReqCard = (id) =>
+    setExpandedReqs((prev) => ({ ...prev, [id]: !prev[id] }));
+  const toggleUpdCard = (id) =>
+    setExpandedUpds((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <div className="relative p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto mt-8 pb-24">
+      <h2 className="text-2xl font-semibold text-gray-800 mb-2 text-center">{title}</h2>
+      {context && (
+        <p className="text-center text-sm text-gray-600 mb-4">
+          {scope === 'pdv'
+            ? `${context.pdvName || context.pdvId || ''} - ${context.subterritory || ''} - ${context.region || ''}`
+            : context.canal || ''}
+        </p>
+      )}
+
+      {/* Filters */}
+      <div className="mb-4 space-y-2">
+        <div className="flex gap-2">
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="border border-gray-300 rounded p-2 flex-1"
+          >
+            <option value="all">Todos</option>
+            <option value="material">Solo Material</option>
+            <option value="updates">Solo Actualizaciones</option>
+          </select>
+          <input
+            type="date"
+            value={fromDate}
+            onChange={(e) => setFromDate(e.target.value)}
+            className="border border-gray-300 rounded p-2"
+          />
+          <input
+            type="date"
+            value={toDate}
+            onChange={(e) => setToDate(e.target.value)}
+            className="border border-gray-300 rounded p-2"
+          />
+        </div>
+        <input
+          type="text"
+          placeholder="Buscar"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border border-gray-300 rounded p-2 w-full"
+        />
+      </div>
+
+      {/* Material Requests Section */}
+      {typeFilter !== 'updates' && (
+        <div className="mb-4">
+          <button
+            onClick={() => setShowReqSection((p) => !p)}
+            className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
+          >
+            <span className="font-semibold text-gray-800">Solicitudes de Material</span>
+            <span className="text-xl">{showReqSection ? '−' : '+'}</span>
+          </button>
+          <div
+            className={`overflow-hidden transition-all duration-300 ${
+              showReqSection ? 'max-h-[1000px] mt-3' : 'max-h-0'
+            }`}
+          >
+            {filteredRequests.length === 0 ? (
+              <p className="text-gray-600 text-center mt-4">No hay datos para mostrar.</p>
+            ) : (
+              <ul className="space-y-4 mt-4">
+                {filteredRequests.map((req) => {
+                  const expanded = expandedReqs[req.id];
+                  const items = expanded ? req.items : req.items.slice(0, 3);
+                  return (
+                    <li key={req.id} className="bg-gray-50 p-4 rounded-lg shadow">
+                      <div className="flex justify-between items-center mb-2">
+                        <div>
+                          <p className="font-semibold text-gray-800 text-sm">
+                            {new Date(req.date).toLocaleDateString()} {scope === 'canal' && `• ${req.pdvName || req.pdvId}`}
+                          </p>
+                          {req.campaign && (
+                            <p className="text-xs text-gray-600">{req.campaign}</p>
+                          )}
+                        </div>
+                        <span className="bg-gray-200 text-xs px-2 py-1 rounded-full">
+                          {req.items.length}
+                        </span>
+                      </div>
+                      <ul className="ml-6 list-disc">
+                        {items.map((item) => (
+                          <li key={item.id}>
+                            {item.displayName} - {item.measure} ({
+                              formatQuantity(item.rawName, item.quantity)
+                            })
+                          </li>
+                        ))}
+                      </ul>
+                      {req.items.length > 3 && (
+                        <button
+                          onClick={() => toggleReqCard(req.id)}
+                          className="text-sm text-tigo-blue mt-2"
+                        >
+                          {expanded ? 'Ver menos' : 'Ver más'}
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* PDV Updates Section */}
+      {typeFilter !== 'material' && (
+        <div className="mb-4">
+          <button
+            onClick={() => setShowUpdSection((p) => !p)}
+            className="w-full flex justify-between items-center bg-gray-100 rounded-lg p-3"
+          >
+            <span className="font-semibold text-gray-800">Actualizaciones de PDV</span>
+            <span className="text-xl">{showUpdSection ? '−' : '+'}</span>
+          </button>
+          <div
+            className={`overflow-hidden transition-all duration-300 ${
+              showUpdSection ? 'max-h-[1000px] mt-3' : 'max-h-0'
+            }`}
+          >
+            {filteredUpdates.length === 0 ? (
+              <p className="text-gray-600 text-center mt-4">No hay datos para mostrar.</p>
+            ) : (
+              <ul className="space-y-4 mt-4">
+                {filteredUpdates.map((up) => {
+                  const fields = [
+                    { label: 'Contacto', value: up.data.contactName },
+                    { label: 'Teléfono', value: up.data.contactPhone },
+                    { label: 'Ciudad', value: up.data.city },
+                    { label: 'Dirección', value: up.data.address },
+                    { label: 'Notas', value: up.data.notes },
+                  ].filter((f) => f.value);
+                  const expanded = expandedUpds[up.id];
+                  const items = expanded ? fields : fields.slice(0, 3);
+                  return (
+                    <li key={up.id} className="bg-gray-50 p-4 rounded-lg shadow">
+                      <div className="mb-2">
+                        <p className="font-semibold text-gray-800 text-sm">
+                          {new Date(up.date).toLocaleDateString()} {scope === 'canal' && `• ${up.pdvName || up.pdvId}`}
+                        </p>
+                      </div>
+                      <ul className="ml-6 list-disc">
+                        {items.map((f, idx) => (
+                          <li key={idx}>
+                            {f.label}: {f.value}
+                          </li>
+                        ))}
+                      </ul>
+                      {fields.length > 3 && (
+                        <button
+                          onClick={() => toggleUpdCard(up.id)}
+                          className="text-sm text-tigo-blue mt-2"
+                        >
+                          {expanded ? 'Ver menos' : 'Ver más'}
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={onBack}
+        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
+      >
+        Volver
+      </button>
+    </div>
+  );
+};
+
+export default HistoryList;
+

--- a/src/utils/historyAdapter.js
+++ b/src/utils/historyAdapter.js
@@ -1,0 +1,71 @@
+import { getDisplayName } from './materialDisplay';
+
+// Build mapping of PDV IDs to normalized info
+export const buildPdvIdMap = (pdvData = {}, regions = [], subterritories = {}) => {
+  const regionMap = Object.fromEntries(regions.map((r) => [r.id, r.name]));
+  const subMap = {};
+  Object.entries(subterritories).forEach(([regionId, subs]) => {
+    subs.forEach((s) => {
+      subMap[s.id] = { name: s.name, regionId };
+    });
+  });
+
+  const map = {};
+  Object.entries(pdvData).forEach(([subId, list]) => {
+    list.forEach((pdv) => {
+      const regionId = pdv.regionId || subMap[subId]?.regionId;
+      map[pdv.id] = {
+        id: pdv.id,
+        pdvName: pdv.name,
+        region: regionMap[regionId] || regionId,
+        subterritory: subMap[subId]?.name || pdv.subterritoryId,
+      };
+    });
+  });
+  return map;
+};
+
+export const adaptMaterialRequests = (raw = [], { idMap = {} } = {}) => {
+  return raw.map((req, idx) => {
+    const info = idMap[req.pdvId] || {};
+    const snapshot = req.pdvSnapshot || req.pdvData;
+    return {
+      id: req.id || `req-${idx}`,
+      date: req.date,
+      type: 'SOLICITUD',
+      canal: req.channelId || req.canal,
+      region: info.region || req.region,
+      subterritory: info.subterritory || req.subterritory,
+      pdvId: info.id || req.pdvId,
+      pdvName: info.pdvName || req.pdvName,
+      pdvSnapshot: snapshot && Object.keys(snapshot).length ? snapshot : undefined,
+      items: (req.items || []).map((item) => ({
+        id: item.id || `${item.material?.id || item.rawName}-${Math.random()}`,
+        displayName: item.displayName || getDisplayName(item.material?.name || item.rawName || ''),
+        measure: item.measures?.name || item.measure || '',
+        quantity: item.quantity,
+        rawName: item.material?.name || item.rawName || '',
+      })),
+      campaign: req.campaign || (req.campaigns && req.campaigns[0]),
+      zones: req.zones,
+      priority: req.priority,
+    };
+  });
+};
+
+export const adaptPdvUpdates = (raw = [], { idMap = {} } = {}) => {
+  return raw.map((up, idx) => {
+    const info = idMap[up.pdvId] || {};
+    return {
+      id: up.id || `upd-${idx}`,
+      date: up.date,
+      type: 'ACTUALIZACIÓN_PDV',
+      region: info.region || up.region,
+      subterritory: info.subterritory || up.subterritory,
+      pdvId: info.id || up.pdvId,
+      pdvName: info.pdvName || up.pdvName,
+      data: up.data || {},
+    };
+  });
+};
+


### PR DESCRIPTION
## Summary
- add reusable `HistoryList` with filters and accordion UX
- normalize history entries via `adaptMaterialRequests` and `adaptPdvUpdates`
- refactor PDV and channel history views to use `HistoryList`

## Testing
- `CI=true npm test` (fails: No tests found, exit code 1)


------
https://chatgpt.com/codex/tasks/task_e_689c262f94d883259cdda398267db836