### PR TITLE
refactor local storage utilities and add developer panel

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,6 +9,7 @@ const Sidebar = ({
   onChannels,
   onCampaigns,
   onExport,
+  onSettings,
   onLogout,
   showManagement,
 }) => {
@@ -94,6 +95,24 @@ const Sidebar = ({
               </svg>
             </Item>
           </>
+        )}
+        {process.env.NODE_ENV === 'development' && onSettings && (
+          <Item onClick={onSettings} label="Ajustes">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="2"
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M11.983 2.25c-.9 0-1.734.516-2.09 1.323L8.35 6.522a1.59 1.59 0 01-1.094.917l-3.492.78c-.87.195-1.592.87-1.592 1.782 0 .913.722 1.588 1.592 1.783l3.492.78c.5.11.9.46 1.094.917l1.543 2.95c.356.807 1.19 1.323 2.09 1.323.9 0 1.734-.516 2.09-1.323l1.543-2.95a1.59 1.59 0 011.094-.917l3.492-.78c.87-.195 1.592-.87 1.592-1.783 0-.912-.722-1.587-1.592-1.782l-3.492-.78a1.59 1.59 0 01-1.094-.917l-1.543-2.95c-.356-.807-1.19-1.323-2.09-1.323z"
+              />
+            </svg>
+          </Item>
         )}
         <Item onClick={onLogout} label="Salir">
           <svg

--- a/src/components/settings/DeveloperPanel.jsx
+++ b/src/components/settings/DeveloperPanel.jsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { sanitizeOnBoot, resetAll } from '../../utils/cleanupLocalStorage';
+import { getStorageItem } from '../../utils/storage';
+import { pdvs } from '../../mock/locations';
+
+/**
+ * Panel de utilidades para desarrolladores.
+ * Permite limpiar o restablecer datos almacenados en el navegador.
+ */
+const DeveloperPanel = ({ onBack }) => {
+  const [result, setResult] = useState(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const getStats = () => {
+    const requests = (getStorageItem('material-requests') || []).length;
+    const updates = (getStorageItem('pdv-update-requests') || []).length;
+    const pdvData = Object.keys(localStorage).filter((k) => /^pdv-.*-data$/.test(k)).length;
+    const defaults = Object.keys(localStorage).filter((k) => /^pdv-.*-defaults-list$/.test(k)).length;
+    return { requests, updates, pdvData, defaults };
+  };
+
+  const [stats, setStats] = useState(getStats());
+
+  const handleCleanup = () => {
+    const validIds = Object.values(pdvs)
+      .flat()
+      .filter((p) => p.complete)
+      .map((p) => p.id);
+    const res = sanitizeOnBoot(validIds);
+    setResult(res);
+    setStats(getStats());
+  };
+
+  const handleReset = () => {
+    resetAll();
+    window.location.reload();
+  };
+
+  return (
+    <div className="w-full max-w-xl space-y-4">
+      <div className="bg-white p-4 rounded shadow">
+        <h2 className="text-lg font-semibold mb-2">Estado actual</h2>
+        <ul className="text-sm space-y-1">
+          <li>Solicitudes: {stats.requests}</li>
+          <li>Actualizaciones: {stats.updates}</li>
+          <li>PDV data: {stats.pdvData}</li>
+          <li>Defaults: {stats.defaults}</li>
+        </ul>
+      </div>
+
+      <div className="bg-white p-4 rounded shadow space-y-2">
+        <button
+          onClick={handleCleanup}
+          className="bg-tigo-blue text-white px-4 py-2 rounded"
+        >
+          Ejecutar limpieza
+        </button>
+        {result && (
+          <pre className="text-xs mt-2 bg-gray-100 p-2 rounded">
+            {JSON.stringify(result, null, 2)}
+          </pre>
+        )}
+      </div>
+
+      <div className="bg-white p-4 rounded shadow space-y-2">
+        <button
+          onClick={() => setShowConfirm(true)}
+          className="bg-red-600 text-white px-4 py-2 rounded"
+        >
+          Restablecer datos locales
+        </button>
+        {showConfirm && (
+          <div className="mt-2 text-sm">
+            <p className="mb-2">
+              Se eliminarán las claves del proyecto en este navegador. ¿Continuar?
+            </p>
+            <div className="space-x-2">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-3 py-1 border rounded"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleReset}
+                className="px-3 py-1 bg-red-600 text-white rounded"
+              >
+                Sí, restablecer
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {onBack && (
+        <button onClick={onBack} className="px-4 py-2 border rounded">
+          Volver
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default DeveloperPanel;

--- a/src/utils/cleanupLocalStorage.js
+++ b/src/utils/cleanupLocalStorage.js
@@ -1,0 +1,166 @@
+import { getStorageItem, setStorageItem, removeStorageItem, PROJECT_KEYS } from './storage';
+
+/**
+ * Crea una copia de seguridad de las claves indicadas.
+ * Las copias se almacenan con el formato `${key}_backup_YYYYMMDD`.
+ *
+ * @param {string[]} keys
+ * @returns {string[]} claves creadas
+ */
+export const backup = (keys = []) => {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const created = [];
+  keys.forEach((key) => {
+    const value = getStorageItem(key);
+    if (value !== null) {
+      const backupKey = `${key}_backup_${date}`;
+      setStorageItem(backupKey, value);
+      created.push(backupKey);
+    }
+  });
+  return created;
+};
+
+/**
+ * Aplica un mapa de IDs normalizados a las entradas almacenadas.
+ *
+ * @param {{[oldId: string]: string}} idMap
+ * @returns {number} cantidad de elementos migrados
+ */
+export const migrateIds = (idMap = {}) => {
+  if (!idMap || Object.keys(idMap).length === 0) return 0;
+  let migrated = 0;
+
+  // Migrar claves de pdv data y defaults
+  Object.keys(localStorage).forEach((key) => {
+    const match = key.match(/^pdv-(.*)-(data|defaults-list)$/);
+    if (match) {
+      const oldId = match[1];
+      const suffix = match[2];
+      const newId = idMap[oldId];
+      if (newId) {
+        const value = getStorageItem(key);
+        removeStorageItem(key);
+        setStorageItem(`pdv-${newId}-${suffix}`, value);
+        migrated++;
+      }
+    }
+  });
+
+  // Migrar listas de solicitudes
+  ['material-requests', 'pdv-update-requests'].forEach((k) => {
+    const arr = getStorageItem(k) || [];
+    const updated = arr.map((entry) => {
+      if (entry && idMap[entry.pdvId]) {
+        migrated++;
+        return { ...entry, pdvId: idMap[entry.pdvId] };
+      }
+      return entry;
+    });
+    setStorageItem(k, updated);
+  });
+
+  return migrated;
+};
+
+/**
+ * Elimina entradas huérfanas del almacenamiento.
+ *
+ * @param {string[]} validIds Lista de IDs válidos de PDV
+ * @returns {number} cantidad de entradas removidas
+ */
+export const cleanupOrphans = (validIds = []) => {
+  if (!validIds || validIds.length === 0) return 0;
+  let removed = 0;
+  const isValid = (id) => validIds.includes(id);
+
+  // limpiar claves de pdv
+  Object.keys(localStorage).forEach((key) => {
+    const match = key.match(/^pdv-(.*)-(data|defaults-list)$/);
+    if (match) {
+      const id = match[1];
+      if (!isValid(id)) {
+        removeStorageItem(key);
+        removed++;
+      }
+    }
+  });
+
+  // limpiar requests sin pdvId válido
+  ['material-requests', 'pdv-update-requests'].forEach((k) => {
+    const arr = (getStorageItem(k) || []).filter(
+      (e) => e && e.pdvId && isValid(e.pdvId)
+    );
+    setStorageItem(k, arr);
+  });
+
+  return removed;
+};
+
+/**
+ * Deduplica solicitudes de material y actualizaciones.
+ *
+ * @returns {number} cantidad de elementos deduplicados
+ */
+export const dedupeRequests = () => {
+  const dedupe = (arr, keyFn) => {
+    const seen = new Set();
+    return arr.filter((item) => {
+      const hash = keyFn(item);
+      if (seen.has(hash)) return false;
+      seen.add(hash);
+      return true;
+    });
+  };
+
+  let deduped = 0;
+  ['material-requests', 'pdv-update-requests'].forEach((k) => {
+    const arr = getStorageItem(k) || [];
+    const filtered = dedupe(arr, (e) =>
+      JSON.stringify({ pdvId: e.pdvId, date: e.date, data: e.data, items: e.items })
+    );
+    deduped += arr.length - filtered.length;
+    setStorageItem(k, filtered);
+  });
+
+  return deduped;
+};
+
+/**
+ * Elimina todas las claves pertenecientes al proyecto.
+ */
+export const resetAll = () => {
+  Object.keys(localStorage).forEach((key) => {
+    if (
+      PROJECT_KEYS.includes(key) ||
+      /^pdv-.*-(data|defaults-list)$/.test(key)
+    ) {
+      removeStorageItem(key);
+    }
+  });
+};
+
+/**
+ * Ejecuta los procesos de saneamiento al iniciar la aplicación.
+ *
+ * @param {string[]} validIds IDs de PDV válidos
+ * @returns {{migrated:number,deduped:number,removed:number,backups:string[]}}
+ */
+export const sanitizeOnBoot = (validIds = []) => {
+  const report = getStorageItem('normalization_report') || {};
+  const backups = backup(['material-requests', 'pdv-update-requests']);
+  const migrated = migrateIds(report.idMap || {});
+  const deduped = dedupeRequests();
+  const removed = cleanupOrphans(validIds);
+  const summary = { migrated, deduped, removed, backups };
+  return summary;
+};
+
+export default {
+  backup,
+  migrateIds,
+  cleanupOrphans,
+  dedupeRequests,
+  resetAll,
+  sanitizeOnBoot,
+};


### PR DESCRIPTION
## Summary
- remove unused `useLocalStorage` hook and document storage helpers
- add centralized localStorage cleanup utilities and developer settings panel
- wire developer panel and sanitize-on-boot into app and sidebar

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689c293dbdbc83259972085e70d4762d