### PR TITLE
feat(ui): unify empty states and add toast feedback

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,7 @@ import { sanitizeOnBoot } from './utils/cleanupLocalStorage';
 import exportToExcel from './utils/exportToExcel';
 import { channels } from './mock/channels';
 import { pdvs } from './mock/locations';
+import { useToast } from './components/ui/ToastProvider';
 
 const App = () => {
   // Controla si el usuario ha iniciado sesión
@@ -60,6 +61,8 @@ const App = () => {
 
   // Mensaje para la pantalla de confirmación
   const [confirmationMessage, setConfirmationMessage] = useState('');
+
+  const addToast = useToast();
 
   // Limpieza y saneamiento inicial de localStorage
   useEffect(() => {
@@ -146,8 +149,10 @@ const App = () => {
   // Exporta la información a un archivo Excel utilizando la utilidad dedicada.
   const performExport = (exportObj) => {
     const success = exportToExcel(exportObj);
-    if (!success) {
-      alert('No se pudo generar el archivo. Intenta de nuevo.');
+    if (success) {
+      addToast('Exportación completada');
+    } else {
+      addToast('No se pudo generar el archivo. Intenta de nuevo.', 'error');
     }
   };
 
@@ -162,6 +167,7 @@ const App = () => {
     const existing = getStorageItem('material-requests') || [];
     setStorageItem('material-requests', [...existing, requestWithDate]);
     setConfirmationMessage(`Solicitud registrada para ${selectedPdvName}`);
+    addToast('Solicitud guardada');
     setCurrentPage('confirm-request');
   };
 
@@ -171,6 +177,7 @@ const App = () => {
   const handleUpdateConfirm = (updatedData) => {
     // console.log('Datos del PDV Actualizados:', updatedData);
     setConfirmationMessage('¡Los datos del PDV han sido actualizados correctamente!');
+    addToast('Datos del PDV guardados');
     setCurrentPage('confirm-update');
   };
 

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { channels } from '../mock/channels';
 import { regions, subterritories, pdvs } from '../mock/locations';
 import { getStorageItem } from '../utils/storage';
+import StateBlock from './ui/StateBlock';
 
 const getPdvInfo = (pdvId) => {
   let subId = '';
@@ -41,6 +42,23 @@ const ExportData = ({ onBack, onExport }) => {
   const [summary, setSummary] = useState(null);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [showNoDataModal, setShowNoDataModal] = useState(false);
+  const summaryRef = useRef(null);
+  const noDataRef = useRef(null);
+  const lastFocused = useRef(null);
+
+  useEffect(() => {
+    if (showSummaryModal && summaryRef.current) {
+      lastFocused.current = document.activeElement;
+      summaryRef.current.focus();
+    }
+  }, [showSummaryModal]);
+
+  useEffect(() => {
+    if (showNoDataModal && noDataRef.current) {
+      lastFocused.current = document.activeElement;
+      noDataRef.current.focus();
+    }
+  }, [showNoDataModal]);
 
 
   const buildExportObject = (requests, scope) => {
@@ -150,6 +168,18 @@ const ExportData = ({ onBack, onExport }) => {
     }
     setShowSummaryModal(false);
     setSummary(null);
+    lastFocused.current && lastFocused.current.focus();
+  };
+
+  const closeSummary = () => {
+    setShowSummaryModal(false);
+    setSummary(null);
+    lastFocused.current && lastFocused.current.focus();
+  };
+
+  const closeNoData = () => {
+    setShowNoDataModal(false);
+    lastFocused.current && lastFocused.current.focus();
   };
 
   return (
@@ -164,23 +194,23 @@ const ExportData = ({ onBack, onExport }) => {
               <button
                 key={ch.id}
                 onClick={() => handleExportChannel(ch.id)}
-                className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all"
+                className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
               >
                 {ch.name}
               </button>
             ))}
             <button
               onClick={() => setCustomMode(true)}
-              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all"
+              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
             >
               PERSONALIZADO
             </button>
           </div>
           <button
             onClick={onBack}
-            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all"
+            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
           >
-            Volver
+            Volver al Inicio
           </button>
         </>
       ) : (
@@ -254,7 +284,7 @@ const ExportData = ({ onBack, onExport }) => {
             <button
               onClick={handleGenerateSummary}
               disabled={!selectedRegion}
-              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all disabled:opacity-50"
+              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-tigo-blue"
             >
               Mostrar resumen
             </button>
@@ -268,16 +298,26 @@ const ExportData = ({ onBack, onExport }) => {
               setSelectedPdv('');
               setSummary(null);
             }}
-            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all"
+            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
           >
-            Cancelar
+            Volver al Inicio
           </button>
         </>
       )}
       {showSummaryModal && summary && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded-xl max-w-sm w-full">
-            <h3 className="text-lg font-semibold mb-2">Resumen de exportación</h3>
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="summary-title"
+          onKeyDown={(e) => e.key === 'Escape' && closeSummary()}
+        >
+          <div
+            ref={summaryRef}
+            tabIndex="-1"
+            className="bg-white p-6 rounded-xl max-w-sm w-full max-h-[80vh] overflow-y-auto"
+          >
+            <h3 id="summary-title" className="text-lg font-semibold mb-2">Resumen de exportación</h3>
             <div className="text-sm mb-4 space-y-1">
               <p>Región: {regions.find((r) => r.id === selectedRegion)?.name}</p>
               {selectedSubterritory && (
@@ -297,14 +337,14 @@ const ExportData = ({ onBack, onExport }) => {
             </div>
             <div className="flex justify-end space-x-2">
               <button
-                onClick={() => setShowSummaryModal(false)}
-                className="px-4 py-2 bg-gray-300 rounded"
+                onClick={closeSummary}
+                className="px-4 py-2 bg-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-tigo-blue"
               >
-                Revisar filtros
+                Revisar otra vez
               </button>
               <button
                 onClick={handleConfirmExport}
-                className="px-4 py-2 bg-green-500 text-white rounded"
+                className="px-4 py-2 bg-green-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-tigo-blue"
               >
                 Exportar
               </button>
@@ -313,16 +353,23 @@ const ExportData = ({ onBack, onExport }) => {
         </div>
       )}
       {showNoDataModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded-xl max-w-sm w-full text-center">
-            <h3 className="text-lg font-semibold mb-2">No hay datos para exportar</h3>
-            <p className="mb-4">Revisa tu selección y filtros.</p>
-            <button
-              onClick={() => setShowNoDataModal(false)}
-              className="px-4 py-2 bg-blue-500 text-white rounded"
-            >
-              Revisar
-            </button>
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          role="dialog"
+          aria-modal="true"
+          onKeyDown={(e) => e.key === 'Escape' && closeNoData()}
+        >
+          <div
+            ref={noDataRef}
+            tabIndex="-1"
+            className="bg-white p-6 rounded-xl max-w-sm w-full max-h-[80vh] overflow-y-auto"
+          >
+            <StateBlock
+              variant="empty"
+              title="No hay datos para exportar. Revisa tu selección y filtros."
+              actionLabel="Revisar otra vez"
+              onAction={closeNoData}
+            />
           </div>
         </div>
       )}

--- a/src/components/history/HistoryList.jsx
+++ b/src/components/history/HistoryList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { formatQuantity } from '../../utils/materialDisplay';
+import StateBlock from '../ui/StateBlock';
 
 const HistoryList = ({
   scope = 'pdv',
@@ -120,7 +121,14 @@ const HistoryList = ({
             }`}
           >
             {filteredRequests.length === 0 ? (
-              <p className="text-gray-600 text-center mt-4">No hay datos para mostrar.</p>
+              <StateBlock
+                variant="empty"
+                title={
+                  scope === 'pdv'
+                    ? 'No hay solicitudes previas para este PDV.'
+                    : 'No hay solicitudes previas.'
+                }
+              />
             ) : (
               <ul className="space-y-4 mt-4">
                 {filteredRequests.map((req) => {
@@ -153,7 +161,7 @@ const HistoryList = ({
                       {req.items.length > 3 && (
                         <button
                           onClick={() => toggleReqCard(req.id)}
-                          className="text-sm text-tigo-blue mt-2"
+                          className="text-sm text-tigo-blue mt-2 focus:outline-none focus:ring-2 focus:ring-tigo-blue"
                         >
                           {expanded ? 'Ver menos' : 'Ver más'}
                         </button>
@@ -183,7 +191,14 @@ const HistoryList = ({
             }`}
           >
             {filteredUpdates.length === 0 ? (
-              <p className="text-gray-600 text-center mt-4">No hay datos para mostrar.</p>
+              <StateBlock
+                variant="empty"
+                title={
+                  scope === 'pdv'
+                    ? 'No hay actualizaciones previas para este PDV.'
+                    : 'No hay actualizaciones previas.'
+                }
+              />
             ) : (
               <ul className="space-y-4 mt-4">
                 {filteredUpdates.map((up) => {
@@ -213,7 +228,7 @@ const HistoryList = ({
                       {fields.length > 3 && (
                         <button
                           onClick={() => toggleUpdCard(up.id)}
-                          className="text-sm text-tigo-blue mt-2"
+                          className="text-sm text-tigo-blue mt-2 focus:outline-none focus:ring-2 focus:ring-tigo-blue"
                         >
                           {expanded ? 'Ver menos' : 'Ver más'}
                         </button>
@@ -229,9 +244,11 @@ const HistoryList = ({
 
       <button
         onClick={onBack}
-        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105"
+        className="fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 max-w-md bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-tigo-blue"
       >
-        Volver
+        {scope === 'pdv'
+          ? `Volver al PDV ${context.pdvName || context.pdvId || ''}`
+          : 'Volver al Canal'}
       </button>
     </div>
   );

--- a/src/components/ui/StateBlock.jsx
+++ b/src/components/ui/StateBlock.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const variantStyles = {
+  empty: 'text-gray-600',
+  loading: 'text-gray-600',
+  error: 'text-red-600',
+};
+
+const StateBlock = ({ variant = 'empty', title, description, actionLabel, onAction }) => {
+  return (
+    <div className={`text-center py-8 ${variantStyles[variant] || ''}`}>
+      {title && <h3 className="text-lg font-semibold mb-2">{title}</h3>}
+      {description && <p className="text-sm mb-4">{description}</p>}
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="px-4 py-2 bg-tigo-blue text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-tigo-blue"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default StateBlock;

--- a/src/components/ui/ToastProvider.jsx
+++ b/src/components/ui/ToastProvider.jsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const ToastContext = createContext(() => {});
+
+export const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = useCallback((message, type = 'success') => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={addToast}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            role="status"
+            className={`px-4 py-2 rounded shadow text-white ${t.type === 'error' ? 'bg-red-600' : 'bg-green-600'}`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,13 @@ import "./styles.css";
 // Punto de entrada de la aplicación React
 
 import App from "./App";
+import { ToastProvider } from "./components/ui/ToastProvider";
 
 const root = createRoot(document.getElementById("root"));
 root.render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add reusable `StateBlock` component for empty/loading/error messages
- introduce `ToastProvider` and hook for success/error toasts
- improve ExportData and HistoryList UI copy, accessibility, and focus styles

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689c30eaac9083258bf6661d9d19c151