### PR TITLE
feat: add Excel location loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ Aplicación React que simula la gestión de solicitudes de material POP y actual
 - **Datos y normalización**: se cargan en formato uniforme, `idMap` para ubicaciones y fallback de datos.
 - **Limpieza y Panel Dev**: herramientas para migrar, limpiar y depurar datos locales.
 
+## Cargar ubicaciones (Excel)
+
+La opción **Cargar ubicaciones** (solo visible en desarrollo) permite reemplazar la
+lista de regiones, subterritorios y PDVs sin necesidad de modificar el código.
+
+1. En la barra lateral elija *Cargar ubicaciones* y seleccione un archivo `.xlsx`.
+2. El Excel debe incluir tres hojas:
+   - **Regions**: columnas `id` (opcional) y `name`.
+   - **Subterritories**: `id` (opcional), `name`, `regionId`.
+   - **PDVs**: `id` (opcional), `name`, `subterritoryId`, `city`, `address`,
+     `contactName`, `contactPhone`, `notes` (opcional).
+3. Se mostrarán los errores de validación detectados. Si no hay errores se
+   genera una vista previa normalizada.
+4. Use **Aplicar en la app** para persistir el dataset en `localStorage` o
+   descargue el resultado como `locations.json` o `locations.js`.
+5. Si los datos quedan corruptos puede utilizar el panel de desarrollador para
+   restablecer las claves `locations_*` en el navegador.
+
 ## Limitaciones actuales
 - No existe backend real; se usan mocks y `localStorage`.
 - Posibles diferencias menores de formato según canal.

--- a/src/App.js
+++ b/src/App.js
@@ -35,7 +35,8 @@ import { sanitizeOnBoot } from './utils/cleanupLocalStorage';
 import exportToExcel from './utils/exportToExcel';
 import exportToJson from './utils/exportToJson';
 import { channels } from './mock/channels';
-import { pdvs } from './mock/locations';
+import { getLocations } from './utils/locationsRuntime';
+import LocationDataLoader from './components/LocationDataLoader';
 import { useToast } from './components/ui/ToastProvider';
 
 const App = () => {
@@ -67,6 +68,7 @@ const App = () => {
 
   // Limpieza y saneamiento inicial de localStorage
   useEffect(() => {
+    const { pdvs } = getLocations();
     const validIds = Object.values(pdvs)
       .flat()
       .filter((p) => p.complete)
@@ -140,6 +142,10 @@ const App = () => {
 
   const handleOpenSettings = () => {
     setCurrentPage('developer-panel');
+  };
+
+  const handleOpenLocationLoader = () => {
+    setCurrentPage('location-loader');
   };
 
   // Navegar directamente al formulario de creación de campaña
@@ -255,6 +261,8 @@ const App = () => {
         return 'Exportar Datos';
       case 'developer-panel':
         return 'Ajustes';
+      case 'location-loader':
+        return 'Cargar Ubicaciones';
       case 'previous-requests':
         return 'Solicitudes Anteriores';
       case 'channel-requests':
@@ -305,6 +313,9 @@ const App = () => {
       case 'developer-panel':
         setCurrentPage('pdv-actions');
         break;
+      case 'location-loader':
+        setCurrentPage('pdv-actions');
+        break;
       case 'confirm-request':
       case 'confirm-update':
         setCurrentPage('home');
@@ -331,6 +342,7 @@ const App = () => {
             onChannels={() => setCurrentPage('channel-select')}
             onCampaigns={() => setCurrentPage('campaigns-menu')}
             onExport={handleExportData}
+            onLoadLocations={handleOpenLocationLoader}
             onSettings={handleOpenSettings}
             onLogout={handleLogout}
             showManagement={selectedTradeType === 'nacional'}
@@ -452,6 +464,11 @@ const App = () => {
         {/* Exportar datos */}
         {isLoggedIn && currentPage === 'export-data' && (
           <ExportData onBack={handleBack} onExport={performExport} />
+        )}
+
+        {/* Carga de ubicaciones desde Excel */}
+        {isLoggedIn && currentPage === 'location-loader' && (
+          <LocationDataLoader onBack={handleBack} />
         )}
 
         {/* Panel de ajustes para desarrolladores */}

--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { getStorageItem } from '../utils/storage';
 import HistoryList from './history/HistoryList';
 import { adaptMaterialRequests, adaptPdvUpdates, buildPdvIdMap } from '../utils/historyAdapter';
-import { regions, subterritories, pdvs } from '../mock/locations';
+import { getLocations } from '../utils/locationsRuntime';
 import { channels } from '../mock/channels';
 
-const idMap = buildPdvIdMap(pdvs, regions, subterritories);
-
 const ChannelRequests = ({ channelId, onBack }) => {
+  const { regions, subterritories, pdvs } = getLocations();
+  const idMap = buildPdvIdMap(pdvs, regions, subterritories);
   const materialRequests = (getStorageItem('material-requests') || []).filter(
     (req) => req.channelId === channelId,
   );

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -1,10 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { channels } from '../mock/channels';
-import { regions, subterritories, pdvs } from '../mock/locations';
+import { getLocations } from '../utils/locationsRuntime';
 import { getStorageItem } from '../utils/storage';
 import StateBlock from './ui/StateBlock';
 
-const getPdvInfo = (pdvId) => {
+const getPdvInfo = (pdvId, { regions, subterritories, pdvs }) => {
   let subId = '';
   let pdvName = pdvId;
   Object.entries(pdvs).forEach(([sId, list]) => {
@@ -35,6 +35,7 @@ const getPdvInfo = (pdvId) => {
 
 
 const ExportData = ({ onBack, onExport }) => {
+  const { regions, subterritories, pdvs } = getLocations();
   const [customMode, setCustomMode] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState('');
   const [selectedSubterritory, setSelectedSubterritory] = useState('');
@@ -65,7 +66,7 @@ const ExportData = ({ onBack, onExport }) => {
     return {
       scope,
       pdvs: requests.map((req) => {
-        const info = getPdvInfo(req.pdvId);
+        const info = getPdvInfo(req.pdvId, { regions, subterritories, pdvs });
         return {
           ...info,
           regionName: req.region || info.regionName,

--- a/src/components/LocationDataLoader.js
+++ b/src/components/LocationDataLoader.js
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { parseExcel, validateRawData, buildNormalized, applyNormalized, toNormalizedJS } from '../utils/locationImport';
+
+/**
+ * Carga datos de ubicaciones desde un archivo Excel y permite aplicarlos a la
+ * aplicación o exportarlos como JSON/JS.
+ */
+const LocationDataLoader = ({ onBack }) => {
+  const [raw, setRaw] = useState(null);
+  const [errors, setErrors] = useState([]);
+  const [warnings, setWarnings] = useState([]);
+  const [normalized, setNormalized] = useState(null);
+
+  const handleFile = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const parsed = await parseExcel(file);
+    setRaw(parsed);
+    const v = validateRawData(parsed.rawRegions, parsed.rawSubterritories, parsed.rawPdvs);
+    setErrors(v.errors);
+    setWarnings(v.warnings);
+    if (v.errors.length === 0) {
+      setNormalized(buildNormalized(parsed));
+    } else {
+      setNormalized(null);
+    }
+  };
+
+  const handleApply = () => {
+    if (!raw || errors.length > 0) return;
+    applyNormalized(raw);
+    alert('Datos aplicados. Recarga la página para ver los cambios.');
+    onBack && onBack();
+  };
+
+  const download = (content, filename, type) => {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDownloadJson = () => {
+    if (!normalized) return;
+    download(JSON.stringify(normalized, null, 2), 'locations.json', 'application/json');
+  };
+
+  const handleDownloadJs = () => {
+    if (!normalized) return;
+    download(toNormalizedJS(normalized), 'locations.js', 'application/javascript');
+  };
+
+  return (
+    <div className="max-w-2xl w-full bg-white p-4 rounded shadow space-y-4">
+      <h2 className="text-xl font-semibold">Cargar ubicaciones</h2>
+      <input type="file" accept=".xlsx" onChange={handleFile} />
+      {errors.length > 0 && (
+        <div className="text-red-600 text-sm">
+          <p>Errores encontrados:</p>
+          <ul className="list-disc pl-4">
+            {errors.map((e, i) => (
+              <li key={i}>{e}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {warnings.length > 0 && (
+        <div className="text-yellow-600 text-sm">
+          <p>Advertencias:</p>
+          <ul className="list-disc pl-4">
+            {warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {normalized && (
+        <div className="space-y-2">
+          <p>
+            Regiones: {normalized.regions.length} - Subterritorios:{' '}
+            {Object.values(normalized.subterritories).flat().length} - PDVs:{' '}
+            {Object.values(normalized.pdvs).flat().length}
+          </p>
+          <div className="space-x-2">
+            <button onClick={handleApply} className="bg-tigo-blue text-white px-3 py-1 rounded">
+              Aplicar en la app
+            </button>
+            <button onClick={handleDownloadJson} className="px-3 py-1 border rounded">
+              Descargar JSON
+            </button>
+            <button onClick={handleDownloadJs} className="px-3 py-1 border rounded">
+              Descargar locations.js
+            </button>
+          </div>
+        </div>
+      )}
+      {onBack && (
+        <button onClick={onBack} className="px-3 py-1 border rounded">
+          Volver
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default LocationDataLoader;

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { regions, subterritories, pdvs } from '../mock/locations';
+import { getLocations } from '../utils/locationsRuntime';
 
 /**
  * Componente encargado de seleccionar la ubicación de un PDV.
@@ -10,6 +10,7 @@ import { regions, subterritories, pdvs } from '../mock/locations';
  */
 
 const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
+  const { regions, subterritories, pdvs } = getLocations();
   const [selectedRegion, setSelectedRegion] = useState('');
   const [selectedSubterritory, setSelectedSubterritory] = useState('');
   const [availableSubterritories, setAvailableSubterritories] = useState([]);

--- a/src/components/PreviousRequests.js
+++ b/src/components/PreviousRequests.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { getStorageItem } from '../utils/storage';
 import HistoryList from './history/HistoryList';
 import { adaptMaterialRequests, adaptPdvUpdates, buildPdvIdMap } from '../utils/historyAdapter';
-import { regions, subterritories, pdvs } from '../mock/locations';
-
-const idMap = buildPdvIdMap(pdvs, regions, subterritories);
+import { getLocations } from '../utils/locationsRuntime';
 
 const PreviousRequests = ({ pdvId, onBack }) => {
+  const { regions, subterritories, pdvs } = getLocations();
+  const idMap = buildPdvIdMap(pdvs, regions, subterritories);
   const materialRequests = (getStorageItem('material-requests') || []).filter(
     (req) => req.pdvId === pdvId,
   );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,6 +9,7 @@ const Sidebar = ({
   onChannels,
   onCampaigns,
   onExport,
+  onLoadLocations,
   onSettings,
   onLogout,
   showManagement,
@@ -95,6 +96,24 @@ const Sidebar = ({
               </svg>
             </Item>
           </>
+        )}
+        {process.env.NODE_ENV === 'development' && onLoadLocations && (
+          <Item onClick={onLoadLocations} label="Cargar ubicaciones">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="2"
+              stroke="currentColor"
+              className="w-5 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+          </Item>
         )}
         {process.env.NODE_ENV === 'development' && onSettings && (
           <Item onClick={onSettings} label="Ajustes">

--- a/src/components/settings/DeveloperPanel.jsx
+++ b/src/components/settings/DeveloperPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { sanitizeOnBoot, resetAll } from '../../utils/cleanupLocalStorage';
 import { getStorageItem } from '../../utils/storage';
-import { pdvs } from '../../mock/locations';
+import { getLocations } from '../../utils/locationsRuntime';
 
 /**
  * Panel de utilidades para desarrolladores.
@@ -22,6 +22,7 @@ const DeveloperPanel = ({ onBack }) => {
   const [stats, setStats] = useState(getStats());
 
   const handleCleanup = () => {
+    const { pdvs } = getLocations();
     const validIds = Object.values(pdvs)
       .flat()
       .filter((p) => p.complete)

--- a/src/utils/locationImport.js
+++ b/src/utils/locationImport.js
@@ -1,0 +1,143 @@
+import * as XLSX from 'xlsx';
+import { normalizeLocationData } from './locationNormalizer';
+import { setLocationsNormalized } from './locationsRuntime';
+import { setStorageItem } from './storage';
+
+// Utilidad simple para generar slugs
+const slugify = (str = '') =>
+  str
+    .toString()
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-');
+
+/**
+ * Lee un archivo Excel y devuelve estructuras crudas.
+ * @param {File} file
+ * @returns {Promise<{rawRegions:Array,rawSubterritories:Array,rawPdvs:Array,issues:Array}>}
+ */
+export const parseExcel = async (file) => {
+  const data = await file.arrayBuffer();
+  const wb = XLSX.read(data, { type: 'array' });
+  const sheetToJson = (name) =>
+    XLSX.utils.sheet_to_json(wb.Sheets[name] || {}, { defval: '' });
+
+  const rawRegions = sheetToJson('Regions').map((r) => ({
+    id: r.id ? String(r.id) : '',
+    name: String(r.name || ''),
+  }));
+
+  const rawSubterritories = sheetToJson('Subterritories').map((s) => ({
+    id: s.id ? String(s.id) : '',
+    name: String(s.name || ''),
+    regionId: String(s.regionId || ''),
+  }));
+
+  const rawPdvs = sheetToJson('PDVs').map((p) => ({
+    id: p.id ? String(p.id) : '',
+    name: String(p.name || ''),
+    subterritoryId: String(p.subterritoryId || ''),
+    city: String(p.city || ''),
+    address: String(p.address || ''),
+    contactName: String(p.contactName || ''),
+    contactPhone: String(p.contactPhone || ''),
+    notes: String(p.notes || ''),
+  }));
+
+  return { rawRegions, rawSubterritories, rawPdvs, issues: [] };
+};
+
+/**
+ * Valida las estructuras crudas importadas del Excel.
+ * @returns {{errors:Array,warnings:Array}}
+ */
+export const validateRawData = (rawRegions = [], rawSubterritories = [], rawPdvs = []) => {
+  const errors = [];
+  const warnings = [];
+
+  const regionIds = new Set();
+  rawRegions.forEach((r, idx) => {
+    if (!r.name) errors.push(`Region fila ${idx + 2}: nombre obligatorio`);
+    if (r.id) {
+      if (regionIds.has(r.id)) errors.push(`Region fila ${idx + 2}: id duplicado ${r.id}`);
+      regionIds.add(r.id);
+    } else warnings.push(`Region fila ${idx + 2}: id faltante`);
+  });
+
+  const subIds = new Set();
+  rawSubterritories.forEach((s, idx) => {
+    if (!s.name) errors.push(`Subterritorio fila ${idx + 2}: nombre obligatorio`);
+    if (!s.regionId || (!regionIds.has(s.regionId)))
+      errors.push(`Subterritorio fila ${idx + 2}: regionId inexistente`);
+    if (s.id) {
+      if (subIds.has(s.id)) errors.push(`Subterritorio fila ${idx + 2}: id duplicado ${s.id}`);
+      subIds.add(s.id);
+    } else warnings.push(`Subterritorio fila ${idx + 2}: id faltante`);
+  });
+
+  const pdvIds = new Set();
+  rawPdvs.forEach((p, idx) => {
+    ['name', 'city', 'address', 'contactName', 'contactPhone', 'subterritoryId'].forEach((f) => {
+      if (!p[f]) errors.push(`PDV fila ${idx + 2}: ${f} obligatorio`);
+    });
+    if (!subIds.has(p.subterritoryId)) errors.push(`PDV fila ${idx + 2}: subterritoryId inexistente`);
+    if (p.id) {
+      if (pdvIds.has(p.id)) warnings.push(`PDV fila ${idx + 2}: id duplicado ${p.id}`);
+      pdvIds.add(p.id);
+    } else warnings.push(`PDV fila ${idx + 2}: id faltante`);
+  });
+
+  return { errors, warnings };
+};
+
+/**
+ * Convierte un dataset normalizado a contenido JavaScript listo para guardar
+ * como `locations.js`.
+ */
+export const toNormalizedJS = ({ regions, subterritories, pdvs }) => {
+  return `import { validateNewPdv } from '../utils/locationNormalizer';\n\nexport const regions = ${JSON.stringify(
+    regions,
+    null,
+    2,
+  )};\nexport const subterritories = ${JSON.stringify(
+    subterritories,
+    null,
+    2,
+  )};\nexport const pdvs = ${JSON.stringify(pdvs, null, 2)};\n\nexport { validateNewPdv };\n`;
+};
+
+/**
+ * Dado un conjunto de datos crudos, devuelve la estructura normalizada y la
+ * aplica a la app inmediatamente.
+ */
+export const buildNormalized = (raw) => {
+  const { rawRegions = [], rawSubterritories = [], rawPdvs = [] } = raw || {};
+  const subMap = {};
+  rawSubterritories.forEach((s) => {
+    if (!subMap[s.regionId]) subMap[s.regionId] = [];
+    subMap[s.regionId].push({ id: s.id || slugify(s.name), name: s.name });
+  });
+  const pdvMap = {};
+  rawPdvs.forEach((p) => {
+    if (!pdvMap[p.subterritoryId]) pdvMap[p.subterritoryId] = [];
+    pdvMap[p.subterritoryId].push({
+      id: p.id || slugify(p.name),
+      name: p.name,
+      city: p.city,
+      address: p.address,
+      contactName: p.contactName,
+      contactPhone: p.contactPhone,
+      notes: p.notes,
+    });
+  });
+  const regionList = rawRegions.map((r) => ({ id: r.id || slugify(r.name), name: r.name }));
+  return normalizeLocationData(regionList, subMap, pdvMap);
+};
+export const applyNormalized = (raw) => {
+  const normalized = buildNormalized(raw);
+  setLocationsNormalized(normalized);
+  setStorageItem('normalization_report', { idMap: {}, duplicatesRemoved: [], warnings: [] });
+  return normalized;
+};
+
+export default { parseExcel, validateRawData, toNormalizedJS, applyNormalized, buildNormalized };

--- a/src/utils/locationNormalizer.js
+++ b/src/utils/locationNormalizer.js
@@ -79,18 +79,26 @@ export const normalizeLocationData = (
       seenIds.add(id);
 
       const regionId = subToRegion[subId] || '';
+      const city = normalizeName(pdv.city || '');
       const address = pdv.address || 'Sin dirección';
-      const contact = pdv.contact || 'Sin contacto';
+      const contactName = normalizeName(pdv.contactName || '');
+      const contactPhone = pdv.contactPhone || '';
+      const notes = pdv.notes || '';
+      const contact = pdv.contact || `${contactName}${contactPhone ? ` - ${contactPhone}` : ''}`;
       const complete = Boolean(
-        id && pdv.name && regionId && subId && address && contact,
+        id && pdv.name && regionId && subId && city && address && contactName && contactPhone,
       );
       return {
         id,
         name: normalizeName(pdv.name || id),
         regionId,
         subterritoryId: subId,
+        city,
         address,
+        contactName,
+        contactPhone,
         contact,
+        notes,
         complete,
       };
     });

--- a/src/utils/locationsRuntime.js
+++ b/src/utils/locationsRuntime.js
@@ -1,0 +1,44 @@
+import { getStorageItem, setStorageItem, removeStorageItem } from './storage';
+import { regions as mockRegions, subterritories as mockSubterritories, pdvs as mockPdvs, validateNewPdv } from '../mock/locations';
+
+/**
+ * Obtiene las ubicaciones disponibles. Si existen datos normalizados en
+ * `localStorage` se devuelven, de lo contrario se usa el mock incluido en
+ * el bundle.
+ */
+export const getLocations = () => {
+  const stored = getStorageItem('locations_normalized');
+  if (
+    stored &&
+    Array.isArray(stored.regions) &&
+    stored.subterritories &&
+    stored.pdvs
+  ) {
+    return stored;
+  }
+  return { regions: mockRegions, subterritories: mockSubterritories, pdvs: mockPdvs };
+};
+
+/**
+ * Persiste un dataset normalizado en `localStorage` y marca el origen.
+ * @param {{regions:Array,subterritories:Object,pdvs:Object}} dataset
+ */
+export const setLocationsNormalized = (dataset) => {
+  if (!dataset) return;
+  setStorageItem('locations_normalized', dataset);
+  setStorageItem('locations_source', 'uploaded');
+};
+
+/**
+ * Limpia los datos de ubicaciones cargados manualmente, regresando al
+ * dataset por defecto.
+ */
+export const clearLocations = () => {
+  removeStorageItem('locations_normalized');
+  removeStorageItem('locations_source');
+  removeStorageItem('normalization_report');
+};
+
+export { validateNewPdv };
+
+export default { getLocations, setLocationsNormalized, clearLocations, validateNewPdv };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -12,7 +12,13 @@
  *
  * @type {string[]}
  */
-export const PROJECT_KEYS = ['material-requests', 'pdv-update-requests'];
+export const PROJECT_KEYS = [
+  'material-requests',
+  'pdv-update-requests',
+  'locations_normalized',
+  'normalization_report',
+  'locations_source',
+];
 
 /**
  * Obtiene un valor del `localStorage` del navegador.


### PR DESCRIPTION
## Summary
- add runtime helpers to switch between uploaded and mock locations
- introduce Excel location loader with validation and export utilities
- document Excel loader workflow in README

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689c3e4ef7f08325a8df600ccf08a389