### PR TITLE
feat: add fallback for missing imported locations

### DIFF
--- a/src/utils/locationsSource.js
+++ b/src/utils/locationsSource.js
@@ -38,7 +38,18 @@ export function getActiveLocations() {
   const imported = getStorageItem(LS_KEY_DATA);
   const source = getStorageItem(LS_KEY_SOURCE);
 
-  if (source === 'imported' && hasImportedData(imported)) {
+  const useImported = source === 'imported' && hasImportedData(imported);
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log(
+      useImported
+        ? '[locations] Usando dataset importado'
+        : '[locations] Usando dataset base',
+    );
+  }
+
+  if (useImported) {
     return {
       regions: imported.regions,
       subterritories: imported.subterritories,
@@ -82,6 +93,26 @@ export function clearImportedLocations() {
 }
 
 export function getLocationsSource() {
-  return getStorageItem(LS_KEY_SOURCE) || 'bundled';
+  const imported = getStorageItem(LS_KEY_DATA);
+  const source = getStorageItem(LS_KEY_SOURCE);
+
+  if (source === 'imported' && hasImportedData(imported)) {
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line no-console
+      console.log('[locations] Fuente actual: dataset importado');
+    }
+    return 'imported';
+  }
+
+  if (source === 'imported') {
+    // invalid import, reset source
+    setStorageItem(LS_KEY_SOURCE, 'bundled');
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log('[locations] Fuente actual: dataset base');
+  }
+  return 'bundled';
 }
 


### PR DESCRIPTION
## Summary
- log which locations dataset is active
- fall back to bundled locations when imported data is missing or invalid
- ensure `getLocationsSource` also falls back and logs source

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689c56abd5f08325bf52bad93926586f