### PR TITLE
Ensure stable location IDs and surface duplicate warnings

### DIFF
--- a/src/components/LocationDataLoader.js
+++ b/src/components/LocationDataLoader.js
@@ -24,6 +24,7 @@ const LocationDataLoader = ({ onBack }) => {
   const [raw, setRaw] = useState(null);
   const [errors, setErrors] = useState([]);
   const [warnings, setWarnings] = useState([]);
+  const [conflicts, setConflicts] = useState([]);
   const [normalized, setNormalized] = useState(null);
   const [active, setActive] = useState(getActiveLocations());
   const addToast = useToast();
@@ -40,10 +41,11 @@ const LocationDataLoader = ({ onBack }) => {
     );
     const allErrors = [...(parsed.issues || []), ...v.errors];
     setErrors(allErrors);
-    setWarnings(v.warnings);
     if (allErrors.length === 0) {
       const norm = buildNormalized(parsed);
       const pdvCount = countPdvs(norm.pdvs);
+      setWarnings([...(v.warnings || []), ...(norm.warnings || [])]);
+      setConflicts(norm.warnings || []);
       if (pdvCount > 0) {
         setNormalized(norm);
         if (process.env.NODE_ENV === 'development') {
@@ -65,6 +67,7 @@ const LocationDataLoader = ({ onBack }) => {
         setNormalized(null);
       }
     } else {
+      setWarnings(v.warnings);
       setNormalized(null);
     }
   };
@@ -76,6 +79,7 @@ const LocationDataLoader = ({ onBack }) => {
       idMap: {},
       duplicatesRemoved: [],
       warnings,
+      conflicts,
     });
     setActive(getActiveLocations());
     if (getLocationsSource() === 'imported') {

--- a/src/utils/locationImport.js
+++ b/src/utils/locationImport.js
@@ -188,7 +188,12 @@ export const buildNormalized = (raw) => {
 export const applyNormalized = (raw) => {
   const normalized = buildNormalized(raw);
   setImportedLocations(normalized);
-  setStorageItem('normalization_report', { idMap: {}, duplicatesRemoved: [], warnings: [] });
+  setStorageItem('normalization_report', {
+    idMap: {},
+    duplicatesRemoved: [],
+    warnings: normalized.warnings || [],
+    conflicts: normalized.warnings || [],
+  });
   return normalized;
 };
 

--- a/src/utils/locationNormalizer.js
+++ b/src/utils/locationNormalizer.js
@@ -15,6 +15,17 @@ const normalizeName = (str = '') =>
     .replace(/\s+/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
 
+// Generates a URL-friendly slug removing accents and special characters
+const slug = (str = '') =>
+  str
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
 /**
  * Normalizes location structures.
  *
@@ -28,14 +39,27 @@ export const normalizeLocationData = (
   subMap = {},
   pdvMap = {},
 ) => {
+  const warnings = [];
+
+  // --- Regiones ---
   const regionMap = new Map();
+  const regionNameMap = new Map(); // slug(name) -> id
   regionList.forEach((r) => {
-    if (r && r.id) {
-      regionMap.set(r.id.trim(), {
-        id: r.id.trim(),
-        name: normalizeName(r.name || r.id),
-      });
+    if (!r) return;
+    const name = normalizeName(r.name || r.id);
+    let id = r.id ? r.id.trim() : `region-${slug(name)}`;
+    let baseId = id;
+    let n = 2;
+    while (regionMap.has(id)) {
+      id = `${baseId}-${n++}`;
     }
+    if (regionNameMap.has(slug(name))) {
+      const prevId = regionNameMap.get(slug(name));
+      warnings.push(`Región "${name}" duplicada (IDs ${prevId} / ${id})`);
+    } else {
+      regionNameMap.set(slug(name), id);
+    }
+    regionMap.set(id, { id, name });
   });
 
   // Ensure all regions referenced in subterritories exist
@@ -46,37 +70,78 @@ export const normalizeLocationData = (
     }
   });
 
-  // Normalize subterritory names
+  // --- Subterritorios ---
   const normalizedSubs = {};
-  Object.entries(subMap).forEach(([regionId, subs]) => {
-    normalizedSubs[regionId] = subs.map((s) => ({
-      id: s.id.trim(),
-      name: normalizeName(s.name || s.id),
-    }));
-  });
-
-  // Map subterritory -> region for quick lookup
+  const globalSubNames = new Map(); // slug(name) -> { name, regions:Set }
+  const subNameById = {}; // id -> name for later reference
   const subToRegion = {};
-  Object.entries(normalizedSubs).forEach(([regionId, subs]) => {
-    subs.forEach((s) => {
-      subToRegion[s.id] = regionId;
+  Object.entries(subMap).forEach(([regionId, subs]) => {
+    const regionName = regionMap.get(regionId)?.name || regionId;
+    const subNamesInRegion = new Map();
+    normalizedSubs[regionId] = subs.map((s) => {
+      const name = normalizeName(s.name || s.id || 'General');
+      let id = s.id ? s.id.trim() : `sub-${slug(regionName)}-${slug(name || 'general')}`;
+      let baseId = id;
+      let n = 2;
+      while (subNameById[id]) {
+        id = `${baseId}-${n++}`;
+      }
+      const nameSlug = slug(name);
+      if (subNamesInRegion.has(nameSlug)) {
+        const prevId = subNamesInRegion.get(nameSlug);
+        warnings.push(
+          `Subterritorio "${name}" duplicado en región "${regionName}" (IDs ${prevId} / ${id})`,
+        );
+      } else {
+        subNamesInRegion.set(nameSlug, id);
+      }
+      const global = globalSubNames.get(nameSlug) || { name, regions: new Set() };
+      global.regions.add(regionId);
+      globalSubNames.set(nameSlug, global);
+
+      subNameById[id] = name;
+      subToRegion[id] = regionId;
+      return { id, name };
     });
   });
 
-  // Normalize PDVs, ensuring unique IDs and required fields
+  // Cross-region subterritory duplicates
+  globalSubNames.forEach((info) => {
+    if (info.regions.size > 1) {
+      const regionNames = Array.from(info.regions).map(
+        (rid) => regionMap.get(rid)?.name || rid,
+      );
+      warnings.push(
+        `Subterritorio "${info.name}" duplicado en regiones ${regionNames.join(' / ')}`,
+      );
+    }
+  });
+
+  // --- PDVs ---
   const seenIds = new Set();
   const normalizedPdvs = {};
   Object.entries(pdvMap).forEach(([subId, list]) => {
+    const subName = subNameById[subId] || subId;
+    const pdvNamesInSub = new Map();
     normalizedPdvs[subId] = list.map((pdv, idx) => {
-      let id = pdv.id ? pdv.id.trim() : '';
-      if (!id || seenIds.has(id)) {
-        id = `${subId}-${idx + 1}`;
-      }
-      // Avoid collisions
+      const name = normalizeName(pdv.name || pdv.id || '');
+      let id = pdv.id ? pdv.id.trim() : `pdv-${slug(name)}`;
+      let baseId = id;
+      let n = 2;
       while (seenIds.has(id)) {
-        id = `${id}-${idx + 1}`;
+        id = `${baseId}-${n++}`;
       }
       seenIds.add(id);
+
+      const nameSlug = slug(name);
+      if (pdvNamesInSub.has(nameSlug)) {
+        const prevId = pdvNamesInSub.get(nameSlug);
+        warnings.push(
+          `PDV "${name}" duplicado en subterritorio "${subName}" (IDs ${prevId} / ${id})`,
+        );
+      } else {
+        pdvNamesInSub.set(nameSlug, id);
+      }
 
       const regionId = subToRegion[subId] || '';
       const city = normalizeName(pdv.city || '');
@@ -84,13 +149,14 @@ export const normalizeLocationData = (
       const contactName = normalizeName(pdv.contactName || '');
       const contactPhone = pdv.contactPhone || '';
       const notes = pdv.notes || '';
-      const contact = pdv.contact || `${contactName}${contactPhone ? ` - ${contactPhone}` : ''}`;
+      const contact =
+        pdv.contact || `${contactName}${contactPhone ? ` - ${contactPhone}` : ''}`;
       const complete = Boolean(
         id && pdv.name && regionId && subId && city && address && contactName && contactPhone,
       );
       return {
         id,
-        name: normalizeName(pdv.name || id),
+        name: name || id,
         regionId,
         subterritoryId: subId,
         city,
@@ -108,6 +174,7 @@ export const normalizeLocationData = (
     regions: Array.from(regionMap.values()),
     subterritories: normalizedSubs,
     pdvs: normalizedPdvs,
+    warnings,
   };
 };
 


### PR DESCRIPTION
## Summary
- generate slug-based IDs for regions, subterritories and PDVs
- track duplicate names and return warnings from normalization
- show conflicts in LocationDataLoader and include them in import report

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cf0618e6083259a19a15756119c0e