### PR TITLE
Restrict location data import to developer panel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -342,7 +342,6 @@ const App = () => {
             onChannels={() => setCurrentPage('channel-select')}
             onCampaigns={() => setCurrentPage('campaigns-menu')}
             onExport={handleExportData}
-            onLoadLocations={handleOpenLocationLoader}
             onSettings={handleOpenSettings}
             onLogout={handleLogout}
             showManagement={selectedTradeType === 'nacional'}
@@ -386,7 +385,6 @@ const App = () => {
           <LocationSelector
             onSelectPdv={handleSelectPdv}
             selectedChannel={selectedChannelId}
-            onOpenLoader={handleOpenLocationLoader}
           />
         )}
 
@@ -477,7 +475,7 @@ const App = () => {
 
         {/* Panel de ajustes para desarrolladores */}
         {isLoggedIn && currentPage === 'developer-panel' && (
-          <DeveloperPanel onBack={handleBack} />
+          <DeveloperPanel onBack={handleBack} onLoadLocations={handleOpenLocationLoader} />
         )}
 
         {/* Mensaje de confirmación de acciones */}

--- a/src/components/LocationDataLoader.js
+++ b/src/components/LocationDataLoader.js
@@ -9,9 +9,9 @@ import {
   setImportedLocations,
   clearImportedLocations,
   getActiveLocations,
-  getLocationsSource,
   countSubs,
   countPdvs,
+  hasImportedData,
 } from '../utils/locationsSource';
 import { setStorageItem } from '../utils/storage';
 import { useToast } from './ui/ToastProvider';
@@ -82,9 +82,8 @@ const LocationDataLoader = ({ onBack }) => {
       conflicts,
     });
     setActive(getActiveLocations());
-    if (getLocationsSource() === 'imported') {
-      addToast('Datos aplicados');
-      onBack && onBack();
+    if (hasImportedData(normalized)) {
+      addToast('Datos importados. Actívalos desde el panel de desarrollador.');
     } else {
       addToast('El archivo importado no contiene registros válidos. Se mantiene el dataset base.');
     }

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -16,7 +16,7 @@ import { pdvsForSub } from '../utils/locationSelectors';
  * peticiones al API.
  */
 
-const LocationSelector = ({ onSelectPdv, selectedChannel, onOpenLoader }) => {
+const LocationSelector = ({ onSelectPdv, selectedChannel: _selectedChannel }) => {
   const { regions, subterritories, pdvs, source, importedAt } = getActiveLocations();
   const importedEmpty =
     source === 'imported' &&
@@ -36,11 +36,6 @@ const LocationSelector = ({ onSelectPdv, selectedChannel, onOpenLoader }) => {
           >
             Usar dataset base
           </button>
-          {onOpenLoader && (
-            <button onClick={onOpenLoader} className="px-3 py-1 border rounded">
-              Ir a Cargar ubicaciones
-            </button>
-          )}
         </div>
       </div>
     );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,7 +9,6 @@ const Sidebar = ({
   onChannels,
   onCampaigns,
   onExport,
-  onLoadLocations,
   onSettings,
   onLogout,
   showManagement,
@@ -96,24 +95,6 @@ const Sidebar = ({
               </svg>
             </Item>
           </>
-        )}
-        {process.env.NODE_ENV === 'development' && onLoadLocations && (
-          <Item onClick={onLoadLocations} label="Cargar ubicaciones">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="2"
-              stroke="currentColor"
-              className="w-5 h-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-          </Item>
         )}
         {process.env.NODE_ENV === 'development' && onSettings && (
           <Item onClick={onSettings} label="Ajustes">

--- a/src/components/settings/DeveloperPanel.jsx
+++ b/src/components/settings/DeveloperPanel.jsx
@@ -1,15 +1,22 @@
 import React, { useState } from 'react';
 import { sanitizeOnBoot, resetAll } from '../../utils/cleanupLocalStorage';
 import { getStorageItem } from '../../utils/storage';
-import { getActiveLocations } from '../../utils/locationsSource';
+import {
+  getActiveLocations,
+  getLocationsSource,
+  setLocationsSource,
+  hasImportedData,
+  LS_KEY_DATA,
+} from '../../utils/locationsSource';
 
 /**
  * Panel de utilidades para desarrolladores.
  * Permite limpiar o restablecer datos almacenados en el navegador.
  */
-const DeveloperPanel = ({ onBack }) => {
+const DeveloperPanel = ({ onBack, onLoadLocations }) => {
   const [result, setResult] = useState(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [locSource, setLocSource] = useState(getLocationsSource());
 
   const getStats = () => {
     const requests = (getStorageItem('material-requests') || []).length;
@@ -37,6 +44,14 @@ const DeveloperPanel = ({ onBack }) => {
     window.location.reload();
   };
 
+  const importedValid = hasImportedData(getStorageItem(LS_KEY_DATA));
+  const handleUseImported = () => {
+    setLocSource(setLocationsSource('imported'));
+  };
+  const handleUseBundled = () => {
+    setLocSource(setLocationsSource('bundled'));
+  };
+
   return (
     <div className="w-full max-w-xl space-y-4">
       <div className="bg-white p-4 rounded shadow">
@@ -60,6 +75,25 @@ const DeveloperPanel = ({ onBack }) => {
           <pre className="text-xs mt-2 bg-gray-100 p-2 rounded">
             {JSON.stringify(result, null, 2)}
           </pre>
+        )}
+      </div>
+
+      <div className="bg-white p-4 rounded shadow space-y-2">
+        <p className="text-sm">Fuente actual: {locSource === 'imported' ? 'Importado' : 'Bundled'}</p>
+        {importedValid && locSource !== 'imported' && (
+          <button onClick={handleUseImported} className="bg-tigo-blue text-white px-4 py-2 rounded">
+            Activar dataset importado
+          </button>
+        )}
+        {locSource === 'imported' && (
+          <button onClick={handleUseBundled} className="px-4 py-2 border rounded">
+            Usar dataset base
+          </button>
+        )}
+        {onLoadLocations && (
+          <button onClick={onLoadLocations} className="px-4 py-2 border rounded">
+            Cargar ubicaciones
+          </button>
         )}
       </div>
 

--- a/src/utils/locationsSource.js
+++ b/src/utils/locationsSource.js
@@ -35,36 +35,14 @@ export const hasImportedData = (imported) =>
 // API ------------------------------------------------------------------
 
 export function getActiveLocations() {
+  const imported = getStorageItem(LS_KEY_DATA);
   const source = getStorageItem(LS_KEY_SOURCE);
 
-  // Si la fuente está fijada a bundled, ignorar cualquier dataset importado
-  if (source === 'bundled') {
-    setStorageItem(LS_KEY_SOURCE, 'bundled');
+  if (source === 'imported' && hasImportedData(imported)) {
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
-      console.log('[locations] Usando dataset base');
+      console.log('[locations] Usando dataset importado');
     }
-    return {
-      regions: bundledRegions,
-      subterritories: bundledSubs,
-      pdvs: bundledPdvs,
-      source: 'bundled',
-    };
-  }
-
-  const imported = getStorageItem(LS_KEY_DATA);
-  const useImported = source === 'imported' && hasImportedData(imported);
-
-  if (process.env.NODE_ENV === 'development') {
-    // eslint-disable-next-line no-console
-    console.log(
-      useImported
-        ? '[locations] Usando dataset importado'
-        : '[locations] Usando dataset base',
-    );
-  }
-
-  if (useImported) {
     return {
       regions: imported.regions,
       subterritories: imported.subterritories,
@@ -76,6 +54,10 @@ export function getActiveLocations() {
 
   // fallback a bundled
   setStorageItem(LS_KEY_SOURCE, 'bundled');
+  if (process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.log('[locations] Usando dataset base');
+  }
   return {
     regions: bundledRegions,
     subterritories: bundledSubs,
@@ -93,9 +75,7 @@ export function setImportedLocations(payload) {
     importedAt: new Date().toISOString(),
   };
   setStorageItem(LS_KEY_DATA, clean);
-  if (hasImportedData(clean)) {
-    setStorageItem(LS_KEY_SOURCE, 'imported');
-  } else {
+  if (!hasImportedData(clean)) {
     // persist but no activar
     setStorageItem(LS_KEY_SOURCE, 'bundled');
   }
@@ -128,6 +108,18 @@ export function getLocationsSource() {
     // eslint-disable-next-line no-console
     console.log('[locations] Fuente actual: dataset base');
   }
+  return 'bundled';
+}
+
+export function setLocationsSource(source) {
+  if (source === 'imported') {
+    const imported = getStorageItem(LS_KEY_DATA);
+    if (hasImportedData(imported)) {
+      setStorageItem(LS_KEY_SOURCE, 'imported');
+      return 'imported';
+    }
+  }
+  setStorageItem(LS_KEY_SOURCE, 'bundled');
   return 'bundled';
 }
 


### PR DESCRIPTION
## Summary
- Default to bundled location dataset and provide explicit source switching
- Reset source when imported data invalid and avoid auto-activation on import
- Move location importer under developer panel with source controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb993549c83258601377ae11ad295