### PR TITLE
Slugify PDV IDs and migrate legacy storage

### DIFF
--- a/src/__tests__/pdvIds.spec.js
+++ b/src/__tests__/pdvIds.spec.js
@@ -1,0 +1,9 @@
+import { pdvs } from '../mock/locations';
+
+describe('PDV IDs', () => {
+  test('use slugged identifiers', () => {
+    const ids = Object.values(pdvs).flat().map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.every((id) => !/^pdv-\d/.test(id))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Generate PDV IDs as slugs combining region, subterritory and name
- Persist old→new ID mapping to migrate localStorage entries
- Add test to ensure PDV IDs are unique and slugged

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689eb995682083259ffa3f1aebc4605b