### PR TITLE
feat: move Excel location import to developer panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,23 @@ Aplicación React que simula la gestión de solicitudes de material POP y actual
 - **Datos y normalización**: se cargan en formato uniforme, `idMap` para ubicaciones y fallback de datos.
 - **Limpieza y Panel Dev**: herramientas para migrar, limpiar y depurar datos locales.
 
-## Cargar ubicaciones (Excel)
+## Importar ubicaciones desde Excel
 
-La opción **Cargar ubicaciones** (solo visible en desarrollo) permite reemplazar la
-lista de regiones, subterritorios y PDVs sin necesidad de modificar el código.
+La importación desde Excel es una **herramienta de administración** disponible solo en modo desarrollo y no forma parte del flujo estándar de la aplicación. Permite reemplazar la lista de regiones, subterritorios y PDVs sin modificar el código.
 
-1. En la barra lateral elija *Cargar ubicaciones* y seleccione un archivo `.xlsx`.
-2. El Excel debe incluir tres hojas:
+1. Abre el panel de ajustes de desarrollador y elige *Cargar ubicaciones*.
+2. Selecciona un archivo `.xlsx`.
+3. El Excel debe incluir tres hojas:
    - **Regions**: columnas `region_id` (opcional) y `region_name`.
    - **Subterritories**: `region_id`, `subterritory_id` (opcional), `subterritory_name`.
    - **PDVs**: `subterritory_id`, `pdv_id` (opcional), `pdv_name` y, de forma opcional,
      `city`, `address` y `contact` (o `contactName`/`contactPhone`).
      También se aceptan los nombres en camelCase (`id`, `name`, `regionId`, etc.).
-3. Se mostrarán los errores de validación detectados. Si no hay errores se
+4. Se mostrarán los errores de validación detectados. Si no hay errores se
    genera una vista previa normalizada.
-4. Use **Aplicar en la app** para persistir el dataset en `localStorage` o
-   descargue el resultado como `locations.json` o `locations.js`.
-5. Si los datos quedan corruptos puede utilizar el panel de desarrollador para
+5. Usa **Aplicar en la app** para persistir el dataset en `localStorage` o
+   descarga el resultado como `locations.json` o `locations.js`.
+6. Si los datos quedan corruptos puedes utilizar el panel de desarrollador para
    restablecer las claves `locations_*` en el navegador.
 
 ## Limitaciones actuales

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,6 @@ import exportToExcel from './utils/exportToExcel';
 import exportToJson from './utils/exportToJson';
 import { channels } from './mock/channels';
 import { getActiveLocations } from './utils/locationsSource';
-import LocationDataLoader from './components/LocationDataLoader';
 import { useToast } from './components/ui/ToastProvider';
 
 const App = () => {
@@ -142,10 +141,6 @@ const App = () => {
 
   const handleOpenSettings = () => {
     setCurrentPage('developer-panel');
-  };
-
-  const handleOpenLocationLoader = () => {
-    setCurrentPage('location-loader');
   };
 
   // Navegar directamente al formulario de creación de campaña
@@ -261,8 +256,6 @@ const App = () => {
         return 'Exportar Datos';
       case 'developer-panel':
         return 'Ajustes';
-      case 'location-loader':
-        return 'Cargar Ubicaciones';
       case 'previous-requests':
         return 'Solicitudes Anteriores';
       case 'channel-requests':
@@ -313,9 +306,6 @@ const App = () => {
       case 'developer-panel':
         setCurrentPage('pdv-actions');
         break;
-      case 'location-loader':
-        setCurrentPage('pdv-actions');
-        break;
       case 'confirm-request':
       case 'confirm-update':
         setCurrentPage('home');
@@ -342,7 +332,6 @@ const App = () => {
             onChannels={() => setCurrentPage('channel-select')}
             onCampaigns={() => setCurrentPage('campaigns-menu')}
             onExport={handleExportData}
-            onLoadLocations={handleOpenLocationLoader}
             onSettings={handleOpenSettings}
             onLogout={handleLogout}
             showManagement={selectedTradeType === 'nacional'}
@@ -386,7 +375,6 @@ const App = () => {
           <LocationSelector
             onSelectPdv={handleSelectPdv}
             selectedChannel={selectedChannelId}
-            onOpenLoader={handleOpenLocationLoader}
           />
         )}
 
@@ -468,11 +456,6 @@ const App = () => {
         {/* Exportar datos */}
         {isLoggedIn && currentPage === 'export-data' && (
           <ExportData onBack={handleBack} onExport={performExport} />
-        )}
-
-        {/* Carga de ubicaciones desde Excel */}
-        {isLoggedIn && currentPage === 'location-loader' && (
-          <LocationDataLoader onBack={handleBack} />
         )}
 
         {/* Panel de ajustes para desarrolladores */}

--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -16,7 +16,7 @@ import { pdvsForSub } from '../utils/locationSelectors';
  * peticiones al API.
  */
 
-const LocationSelector = ({ onSelectPdv, selectedChannel, onOpenLoader }) => {
+const LocationSelector = ({ onSelectPdv, selectedChannel }) => {
   const { regions, subterritories, pdvs, source, importedAt } = getActiveLocations();
   const importedEmpty =
     source === 'imported' &&
@@ -36,11 +36,6 @@ const LocationSelector = ({ onSelectPdv, selectedChannel, onOpenLoader }) => {
           >
             Usar dataset base
           </button>
-          {onOpenLoader && (
-            <button onClick={onOpenLoader} className="px-3 py-1 border rounded">
-              Ir a Cargar ubicaciones
-            </button>
-          )}
         </div>
       </div>
     );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,7 +9,6 @@ const Sidebar = ({
   onChannels,
   onCampaigns,
   onExport,
-  onLoadLocations,
   onSettings,
   onLogout,
   showManagement,
@@ -96,24 +95,6 @@ const Sidebar = ({
               </svg>
             </Item>
           </>
-        )}
-        {process.env.NODE_ENV === 'development' && onLoadLocations && (
-          <Item onClick={onLoadLocations} label="Cargar ubicaciones">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth="2"
-              stroke="currentColor"
-              className="w-5 h-5"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-          </Item>
         )}
         {process.env.NODE_ENV === 'development' && onSettings && (
           <Item onClick={onSettings} label="Ajustes">

--- a/src/components/settings/DeveloperPanel.jsx
+++ b/src/components/settings/DeveloperPanel.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { sanitizeOnBoot, resetAll } from '../../utils/cleanupLocalStorage';
 import { getStorageItem } from '../../utils/storage';
 import { getActiveLocations } from '../../utils/locationsSource';
+import LocationDataLoader from '../LocationDataLoader';
 
 /**
  * Panel de utilidades para desarrolladores.
@@ -10,6 +11,7 @@ import { getActiveLocations } from '../../utils/locationsSource';
 const DeveloperPanel = ({ onBack }) => {
   const [result, setResult] = useState(null);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
 
   const getStats = () => {
     const requests = (getStorageItem('material-requests') || []).length;
@@ -36,6 +38,10 @@ const DeveloperPanel = ({ onBack }) => {
     resetAll();
     window.location.reload();
   };
+
+  if (showLoader) {
+    return <LocationDataLoader onBack={() => setShowLoader(false)} />;
+  }
 
   return (
     <div className="w-full max-w-xl space-y-4">
@@ -92,6 +98,17 @@ const DeveloperPanel = ({ onBack }) => {
           </div>
         )}
       </div>
+
+      {process.env.NODE_ENV === 'development' && (
+        <div className="bg-white p-4 rounded shadow space-y-2">
+          <button
+            onClick={() => setShowLoader(true)}
+            className="bg-tigo-blue text-white px-4 py-2 rounded"
+          >
+            Cargar ubicaciones
+          </button>
+        </div>
+      )}
 
       {onBack && (
         <button onClick={onBack} className="px-4 py-2 border rounded">


### PR DESCRIPTION
## Summary
- remove LocationDataLoader entry points from main navigation
- allow opening LocationDataLoader from DeveloperPanel in dev mode
- clarify that Excel import is an admin-only tool

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eb996cb50832595437fe95dc0d52e