### PR TITLE
Use local location dataset and show PDVs

### DIFF
--- a/src/components/LocationSelector.js
+++ b/src/components/LocationSelector.js
@@ -65,8 +65,9 @@ const LocationSelector = ({ onSelectPdv, selectedChannel: _selectedChannel }) =>
   useEffect(() => {
     if (selectedSubterritory) {
       const list = pdvsForSub(selectedSubterritory);
-      // Mostrar únicamente PDVs completos
-      setAvailablePdvs(list.filter((p) => p.complete));
+      // Mostrar todos los PDVs disponibles para el subterritorio seleccionado
+      // (filtrado por "complete" se deshabilita temporalmente)
+      setAvailablePdvs(list);
       setSearchTerm('');
     } else {
       setAvailablePdvs([]);
@@ -151,7 +152,8 @@ const LocationSelector = ({ onSelectPdv, selectedChannel: _selectedChannel }) =>
             <option value="">Selecciona un PDV</option>
             {availablePdvs
               .filter((pdv) =>
-                pdv.name.toLowerCase().includes(searchTerm.toLowerCase())
+                pdv.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                pdv.id.toLowerCase().includes(searchTerm.toLowerCase())
               )
               .map((pdv) => (
                 <option key={pdv.id} value={pdv.id}>{pdv.name}</option>

--- a/src/mock/locations.js
+++ b/src/mock/locations.js
@@ -146,12 +146,8 @@ Object.entries(rawPdvs).forEach(([subId, list]) => {
   });
 });
 
-// Normalize again using the new slugs
-const { regions, subterritories, pdvs } = normalizeLocationData(
-=======
 // Perform normalization to clean and enrich the data structures
 const { regions, subterritories, pdvs, warnings } = normalizeLocationData(
-
   rawRegions,
   rawSubterritories,
   sluggedPdvs,
@@ -174,19 +170,19 @@ if (typeof window !== 'undefined' && window.localStorage) {
     conflicts: [],
   });
 
-if (warnings.length > 0) {
-  if (process.env.NODE_ENV === 'development') {
-    try {
-      localStorage.setItem('normalization_report', JSON.stringify(warnings));
-    } catch (err) {
-      // ignore storage errors
+  if (warnings.length > 0) {
+    if (process.env.NODE_ENV === 'development') {
+      try {
+        localStorage.setItem('normalization_report', JSON.stringify(warnings));
+      } catch (err) {
+        // ignore storage errors
+      }
     }
+    console.groupCollapsed('[Normalization] Inconsistencias en dataset embebido');
+    console.warn(`${warnings.length} inconsistencias detectadas`);
+    console.table(warnings.map((w, i) => ({ '#': i + 1, mensaje: w })));
+    console.groupEnd();
   }
-  console.groupCollapsed('[Normalization] Inconsistencias en dataset embebido');
-  console.warn(`${warnings.length} inconsistencias detectadas`);
-  console.table(warnings.map((w, i) => ({ '#': i + 1, mensaje: w })));
-  console.groupEnd();
-
 }
 
 export { regions, subterritories, pdvs, validateNewPdv };


### PR DESCRIPTION
## Summary
- Show all PDVs from the local dataset and allow searching by name or ID
- Restore normalized locations dataset with slugged IDs and remove merge conflict markers

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ecb41f84c83259ad78a79eb20151d