### PR TITLE
Configure MySQL connection on port 3307

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE_URL=http://localhost:8080/api
+REACT_APP_API_BASE_URL=http://localhost:8000/api

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Aplicación React que simula la gestión de solicitudes de material POP y actual
 - Ejecutar en desarrollo: `npm start`
 - Ejecutar pruebas: `npm test`
 - Generar build de producción: `npm run build`
+- Backend PHP disponible en `backend/public/index.php`
+  - Servidor PHP: `php -S localhost:8000`
+  - MySQL: `127.0.0.1:3307` (base `base_dest`, usuario `root`, contraseña `Bermudez2020*`)
 
 ## Estructura
 - **src/**: componentes React, utilidades y datos mock.

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -7,11 +7,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') exit;
 
 header('Content-Type: application/json');
 
-// AJUSTAR CREDENCIALES AQUÍ
+// Conexión a MySQL (puerto exclusivo 3307)
 $pdo = new PDO(
-  'mysql:host=127.0.0.1;dbname=base_dest;charset=utf8mb4',
-  'root', 'TU_PASSWORD',
-  [ PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE=>PDO::FETCH_ASSOC ]
+  'mysql:host=127.0.0.1;port=3307;dbname=base_dest;charset=utf8mb4',
+  'root',
+  'Bermudez2020*',
+  [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
+  ]
 );
 
 // Normaliza path y base /api

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,4 +1,4 @@
-const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080/api';
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8000/api';
 
 async function http(path, options = {}) {
   const res = await fetch(`${API_BASE}${path}`, {


### PR DESCRIPTION
## Summary
- Configure backend PDO DSN for MySQL on 127.0.0.1:3307 with root credentials
- Point frontend API base to PHP server on port 8000
- Document backend connection details and ports

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a6657a44c483259af4cbfc35e35eba