### PR TITLE
feat: add LocalStorage fallback for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ docker compose up -d
 ```
 Levanta MySQL (3307) y PHP (8000).
 
+## Modo demo
+En modo demo, las solicitudes se guardan en `LocalStorage`. Para producción, debe reemplazarse esta lógica con los endpoints reales del backend.
+
 ## API
 Límite de payload: 1MB (HTTP 413 si se excede).
 Paginación: `limit` (1–100), `offset` (>=0). Filtros: `region_id`, `subterritorio_id`, `pdv_id`, `campaña_id`. Orden: `id DESC`.

--- a/src/components/MaterialRequestForm.js
+++ b/src/components/MaterialRequestForm.js
@@ -3,8 +3,8 @@ import {
   getChannels,
   getMaterialsByChannel,
   getCampaigns,
-  createRequest,
 } from '../services/api';
+import { createRequest } from '../services/requests';
 import ContextInfo from './ContextInfo';
 import SingleSelectModal from './SingleSelectModal';
 import PreviousCampaignsModal from './PreviousCampaignsModal';

--- a/src/pages/RequestDetail.jsx
+++ b/src/pages/RequestDetail.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { getRequest } from '../services/api';
+import { getRequest } from '../services/requests';
 
 export default function RequestDetail() {
   const { id } = useParams();

--- a/src/pages/RequestsHistory.jsx
+++ b/src/pages/RequestsHistory.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { listRequests, getRegions, getSubterritories, getPdvs, getCampaigns } from '../services/api';
+import { listRequests } from '../services/requests';
+import { getRegions, getSubterritories, getPdvs, getCampaigns } from '../services/api';
 
 export default function RequestsHistory() {
   const [regions, setRegions] = useState([]);
@@ -30,26 +31,35 @@ export default function RequestsHistory() {
   }, []);
 
   // Dependencia: región -> subterritorios
+  const regionId = filters.region_id;
   useEffect(() => {
     (async () => {
-      setSubs([]); setPdvs([]);
+      setSubs([]);
+      setPdvs([]);
       setFilters(f => ({ ...f, subterritorio_id: '', pdv_id: '' }));
-      if (!filters.region_id) return;
-      try { setSubs(await getSubterritories(filters.region_id)); } catch (e) { console.error(e); }
+      if (!regionId) return;
+      try {
+        setSubs(await getSubterritories(regionId));
+      } catch (e) {
+        console.error(e);
+      }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters.region_id]);
+  }, [regionId]);
 
   // Dependencia: subterritorio -> pdvs
+  const subId = filters.subterritorio_id;
   useEffect(() => {
     (async () => {
       setPdvs([]);
       setFilters(f => ({ ...f, pdv_id: '' }));
-      if (!filters.subterritorio_id) return;
-      try { setPdvs(await getPdvs(filters.subterritorio_id)); } catch (e) { console.error(e); }
+      if (!subId) return;
+      try {
+        setPdvs(await getPdvs(subId));
+      } catch (e) {
+        console.error(e);
+      }
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters.subterritorio_id]);
+  }, [subId]);
 
   const queryKey = useMemo(
     () => JSON.stringify({ limit: page.limit, offset: page.offset, filters }),

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -24,17 +24,3 @@ export const getChannels = () => http('/channels');
 export const getMaterials = () => http('/materials');
 export const getMaterialsByChannel = (channelId) => http(`/channels/${encodeURIComponent(channelId)}/materials`);
 export const getCampaigns = () => http('/campaigns');
-
-// ---------- Solicitudes ----------
-export const createRequest = (payload) => http('/requests', { method: 'POST', body: JSON.stringify(payload) });
-export const getRequest = (id) => http(`/requests/${id}`);
-export async function listRequests({ limit = 10, offset = 0, filters = {} } = {}) {
-  const params = new URLSearchParams();
-  params.set('limit', String(limit));
-  params.set('offset', String(offset));
-  if (filters.region_id) params.set('region_id', filters.region_id);
-  if (filters.subterritorio_id) params.set('subterritorio_id', filters.subterritorio_id);
-  if (filters.pdv_id) params.set('pdv_id', filters.pdv_id);
-  if (filters['campaña_id']) params.set('campaña_id', filters['campaña_id']);
-  return http(`/requests?${params.toString()}`);
-}

--- a/src/services/requests.js
+++ b/src/services/requests.js
@@ -1,0 +1,122 @@
+const API_BASE = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API)
+  || process.env.REACT_APP_API;
+
+import { getStorageItem, setStorageItem } from '../utils/storage';
+
+const STORAGE_KEY = 'requests';
+
+export function getRequestsLocal() {
+  return getStorageItem(STORAGE_KEY) || [];
+}
+
+export function getRequestLocal(id) {
+  const all = getRequestsLocal();
+  return all.find(r => String(r.id) === String(id)) || null;
+}
+
+export function saveRequestLocal(payload) {
+  const all = getRequestsLocal();
+  const nextId = all.length ? Math.max(...all.map(r => r.id)) + 1 : 1;
+  const record = {
+    id: nextId,
+    header: {
+      region_id: payload.regionId,
+      subterritorio_id: payload.subterritoryId,
+      pdv_id: payload.pdvId,
+      campaña_id: payload.campaignId || null,
+      prioridad: payload.priority || null,
+      zonas: payload.zones || [],
+      observaciones: payload.observations || '',
+      creado_por: payload.createdBy || '',
+      creado_en: new Date().toISOString(),
+    },
+    items: payload.items.map((item, idx) => ({
+      id: idx + 1,
+      material_id: item.materialId,
+      cantidad: item.quantity,
+      medida_etiqueta: item.measureTag,
+      medida_custom: item.measureCustom,
+      observaciones: item.observations || '',
+    })),
+  };
+  all.push(record);
+  setStorageItem(STORAGE_KEY, all);
+  return record;
+}
+
+export async function createRequest(payload) {
+  if (API_BASE) {
+    // TODO backend: reemplazar o ajustar llamada a la API real según sea necesario
+    const res = await fetch(`${API_BASE}/requests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`HTTP ${res.status} ${txt}`);
+    }
+    return res.json();
+  }
+  // TODO backend: utilizar API real en lugar de LocalStorage
+  const record = saveRequestLocal(payload);
+  return { id: record.id };
+}
+
+export async function listRequests({ limit = 10, offset = 0, filters = {} } = {}) {
+  if (API_BASE) {
+    // TODO backend: reemplazar llamada a la API real si es necesario
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    params.set('offset', String(offset));
+    if (filters.region_id) params.set('region_id', filters.region_id);
+    if (filters.subterritorio_id) params.set('subterritorio_id', filters.subterritorio_id);
+    if (filters.pdv_id) params.set('pdv_id', filters.pdv_id);
+    if (filters['campaña_id']) params.set('campaña_id', filters['campaña_id']);
+    const res = await fetch(`${API_BASE}/requests?${params.toString()}`);
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`HTTP ${res.status} ${txt}`);
+    }
+    return res.json();
+  }
+  // TODO backend: usar datos del backend real
+  const all = getRequestsLocal().filter(r => {
+    const h = r.header;
+    if (filters.region_id && h.region_id !== filters.region_id) return false;
+    if (filters.subterritorio_id && h.subterritorio_id !== filters.subterritorio_id) return false;
+    if (filters.pdv_id && h.pdv_id !== filters.pdv_id) return false;
+    if (filters['campaña_id'] && h.campaña_id !== filters['campaña_id']) return false;
+    return true;
+  });
+  const slice = all.slice(offset, offset + limit);
+  const data = slice.map(r => ({
+    id: r.id,
+    region_id: r.header.region_id,
+    subterritorio_id: r.header.subterritorio_id,
+    pdv_id: r.header.pdv_id,
+    campaña_id: r.header.campaña_id,
+    prioridad: r.header.prioridad,
+    items_count: r.items.length,
+    creado_por: r.header.creado_por,
+    creado_en: r.header.creado_en,
+  }));
+  return { data, page: { total: all.length } };
+}
+
+export async function getRequest(id) {
+  if (API_BASE) {
+    // TODO backend: reemplazar llamada a la API real si es necesario
+    const res = await fetch(`${API_BASE}/requests/${id}`);
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`HTTP ${res.status} ${txt}`);
+    }
+    return res.json();
+  }
+  // TODO backend: utilizar API real en lugar de LocalStorage
+  const rec = getRequestLocal(id);
+  if (!rec) throw new Error('Solicitud no encontrada');
+  return rec;
+}
+


### PR DESCRIPTION
- Añadir servicio de solicitud basado en LocalStorage con respaldo del backend.
- Conectar las páginas de la interfaz de usuario para que utilicen el nuevo servicio de solicitud.
- Documentar el uso de LocalStorage en modo demo.
- Optimizar las dependencias del hook de historial para evitar incumplir la regla ESLint.