### PR TITLE
Add demo-mode LocalStorage data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker compose up -d
 Levanta MySQL (3307) y PHP (8000).
 
 ## Modo demo
-En modo demo, las solicitudes se guardan en `LocalStorage`. Para producción, debe reemplazarse esta lógica con los endpoints reales del backend.
+En modo demo, los catálogos y las solicitudes se cargan desde `LocalStorage` utilizando los mocks incluidos. Para producción, esta lógica se reemplaza por llamadas a la API real del backend.
 
 ## API
 Límite de payload: 1MB (HTTP 413 si se excede).

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ import { getStorageItem, setStorageItem } from './utils/storage';
 import { sanitizeOnBoot } from './utils/cleanupLocalStorage';
 import exportToExcel from './utils/exportToExcel';
 import exportToJson from './utils/exportToJson';
-import { channels } from './mock/channels';
+import { getChannels } from './services/api';
 import { getActiveLocations } from './utils/locationsSource';
 import { useToast } from './components/ui/ToastProvider';
 
@@ -51,6 +51,7 @@ const App = () => {
 
   // Identificador del canal seleccionado
   const [selectedChannelId, setSelectedChannelId] = useState('');
+  const [channelList, setChannelList] = useState([]);
 
   // Identificador del PDV seleccionado
   const [selectedPdvId, setSelectedPdvId] = useState('');
@@ -76,6 +77,11 @@ const App = () => {
     if (process.env.NODE_ENV === 'development') {
       console.log('sanitizeOnBoot report', report);
     }
+  }, []);
+
+  // Cargar canales disponibles desde LocalStorage
+  useEffect(() => {
+    getChannels().then(setChannelList).catch(console.error);
   }, []);
 
   // Usuario selecciona si trabajará con Trade Nacional o Regional
@@ -237,7 +243,7 @@ const App = () => {
       case 'channel-select':
         return 'Selección de Canal';
       case 'channel-menu':
-        return `Canal ${channels.find((c) => c.id === selectedChannelId)?.name || selectedChannelId}`;
+        return `Canal ${channelList.find((c) => c.id === selectedChannelId)?.name || selectedChannelId}`;
       case 'location-select':
         return 'Selección de Ubicación';
       case 'pdv-actions':

--- a/src/components/ChannelMenu.js
+++ b/src/components/ChannelMenu.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { channels } from '../mock/channels';
+import React, { useEffect, useState } from 'react';
+import { getChannels } from '../services/api';
 
 /**
  * Menú principal de un canal.
@@ -8,7 +8,15 @@ import { channels } from '../mock/channels';
  * consultar el historial de solicitudes del canal.
  */
 const ChannelMenu = ({ channelId, onSelectPdv, onViewRequests }) => {
-  const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
+  const [channelName, setChannelName] = useState(channelId);
+
+  useEffect(() => {
+    getChannels()
+      .then((list) => {
+        setChannelName(list.find((c) => c.id === channelId)?.name || channelId);
+      })
+      .catch(console.error);
+  }, [channelId]);
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto text-center">

--- a/src/components/ChannelRequests.js
+++ b/src/components/ChannelRequests.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { getStorageItem } from '../utils/storage';
 import HistoryList from './history/HistoryList';
 import { adaptMaterialRequests, adaptPdvUpdates, buildPdvIdMap } from '../utils/historyAdapter';
 import { getActiveLocations } from '../utils/locationsSource';
-import { channels } from '../mock/channels';
+import { getChannels } from '../services/api';
 
 const ChannelRequests = ({ channelId, onBack }) => {
   const { regions, subterritories, pdvs } = getActiveLocations();
@@ -18,7 +18,15 @@ const ChannelRequests = ({ channelId, onBack }) => {
 
   const requests = adaptMaterialRequests(materialRequests, { idMap });
   const updates = adaptPdvUpdates(updateRequests, { idMap });
-  const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
+  const [channelName, setChannelName] = useState(channelId);
+
+  useEffect(() => {
+    getChannels()
+      .then((list) => {
+        setChannelName(list.find((c) => c.id === channelId)?.name || channelId);
+      })
+      .catch(console.error);
+  }, [channelId]);
 
   return (
     <HistoryList

--- a/src/components/ChannelSelector.js
+++ b/src/components/ChannelSelector.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { channels } from '../mock/channels';
+import React, { useEffect, useState } from 'react';
+import { getChannels } from '../services/api';
 
 /**
  * Selector de canal.
@@ -13,11 +13,17 @@ import { channels } from '../mock/channels';
 // `onCreateCampaign` y `onExportData` son opcionales y permiten acceder
 // directamente a la creación de campañas o a la exportación de datos.
 const ChannelSelector = ({ onSelectChannel, onCreateCampaign, onExportData }) => {
+  const [channels, setChannels] = useState([]);
+
+  useEffect(() => {
+    getChannels().then(setChannels).catch(console.error);
+  }, []);
+
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-3xl mx-auto mt-8">
       <h2 className="text-2xl font-semibold text-gray-800 mb-6 text-center">Selecciona un Canal</h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {/* Reemplazar `channels` por datos obtenidos desde la API */}
+        {/* TODO backend: obtener canales desde API real */}
         {channels.map((channel) => (
           <button
             key={channel.id}

--- a/src/components/ContextInfo.js
+++ b/src/components/ContextInfo.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { channels } from '../mock/channels';
+import React, { useEffect, useState } from 'react';
+import { getChannels } from '../services/api';
 
 /**
  * Muestra un resumen del contexto desde el cual se realiza la solicitud.
@@ -8,7 +8,15 @@ import { channels } from '../mock/channels';
  * el subterritorio, la región y el canal actual mientras revisa el carrito.
  */
 const ContextInfo = ({ pdvName, subterritoryName, regionName, channelId }) => {
-  const channelName = channels.find((c) => c.id === channelId)?.name || channelId;
+  const [channelName, setChannelName] = useState(channelId);
+
+  useEffect(() => {
+    getChannels()
+      .then((list) => {
+        setChannelName(list.find((c) => c.id === channelId)?.name || channelId);
+      })
+      .catch(console.error);
+  }, [channelId]);
   return (
     <div className="mb-4 bg-tigo-light p-3 rounded-lg text-gray-800 text-sm">
       <p className="font-semibold">PDV: {pdvName}</p>

--- a/src/components/CreateCampaignForm.js
+++ b/src/components/CreateCampaignForm.js
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { campaigns } from '../mock/campaigns';
-import { channels } from '../mock/channels';
-import { materials } from '../mock/materials';
-import { channelMaterials } from '../mock/channelMaterials';
+import { getStorageItem } from '../utils/storage';
+import { channels as defaultChannels } from '../mock/channels';
+import { materials as defaultMaterials } from '../mock/materials';
+import { channelMaterials as defaultChannelMaterials } from '../mock/channelMaterials';
 import MaterialSelectorModal from './MaterialSelectorModal';
 import { getDisplayName, formatQuantity } from '../utils/materialDisplay';
 
@@ -84,6 +85,16 @@ const CreateCampaignForm = ({ onBack }) => {
       [id]: { ...prev[id], customMeasure: value },
     }));
 
+  const [channels, setChannels] = useState([]);
+  const [materials, setMaterials] = useState([]);
+  const [channelMaterials, setChannelMaterials] = useState({});
+
+  useEffect(() => {
+    setChannels(getStorageItem('channels') || defaultChannels);
+    setMaterials(getStorageItem('materials') || defaultMaterials);
+    setChannelMaterials(getStorageItem('channelMaterials') || defaultChannelMaterials);
+  }, []);
+
   const materialsWithChannels = React.useMemo(() => {
     const result = {};
     Object.entries(channelMaterials).forEach(([ch, mats]) => {
@@ -106,7 +117,7 @@ const CreateCampaignForm = ({ onBack }) => {
         (cid) => channels.find((c) => c.id === cid)?.name || cid,
       ),
     }));
-  }, []);
+  }, [channelMaterials, materials, channels]);
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-md mx-auto space-y-4">

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { channels } from '../mock/channels';
+import { getChannels } from '../services/api';
 import { getActiveLocations } from '../utils/locationsSource';
 import { pdvsForSub } from '../utils/locationSelectors';
 import { getStorageItem } from '../utils/storage';
@@ -38,6 +38,7 @@ const getPdvInfo = (pdvId) => {
 
 const ExportData = ({ onBack, onExport }) => {
   const { regions, subterritories } = getActiveLocations();
+  const [channels, setChannels] = useState([]);
   const [customMode, setCustomMode] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState('');
   const [selectedSubterritory, setSelectedSubterritory] = useState('');
@@ -48,6 +49,10 @@ const ExportData = ({ onBack, onExport }) => {
   const summaryRef = useRef(null);
   const noDataRef = useRef(null);
   const lastFocused = useRef(null);
+
+  useEffect(() => {
+    getChannels().then(setChannels).catch(console.error);
+  }, []);
 
   useEffect(() => {
     if (showSummaryModal && summaryRef.current) {

--- a/src/components/ManageCampaigns.js
+++ b/src/components/ManageCampaigns.js
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { campaigns as defaultCampaigns } from '../mock/campaigns';
-import { channels } from '../mock/channels';
-import { materials } from '../mock/materials';
-import { channelMaterials } from '../mock/channelMaterials';
+import { getStorageItem } from '../utils/storage';
+import { channels as defaultChannels } from '../mock/channels';
+import { materials as defaultMaterials } from '../mock/materials';
+import { channelMaterials as defaultChannelMaterials } from '../mock/channelMaterials';
 
 /**
  * Panel para editar o eliminar campañas existentes.
@@ -10,6 +11,16 @@ import { channelMaterials } from '../mock/channelMaterials';
  */
 const ManageCampaigns = ({ onBack }) => {
   const [list, setList] = useState([]);
+
+  const [channels, setChannels] = useState([]);
+  const [materials, setMaterials] = useState([]);
+  const [channelMaterials, setChannelMaterials] = useState({});
+
+  useEffect(() => {
+    setChannels(getStorageItem('channels') || defaultChannels);
+    setMaterials(getStorageItem('materials') || defaultMaterials);
+    setChannelMaterials(getStorageItem('channelMaterials') || defaultChannelMaterials);
+  }, []);
 
   const channelsByMaterial = React.useMemo(() => {
     const result = {};
@@ -28,7 +39,7 @@ const ManageCampaigns = ({ onBack }) => {
       }
     });
     return result;
-  }, []);
+  }, [channelMaterials, materials]);
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem('campaigns'));

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,11 @@ import App from "./App";
 import RequestsHistory from "./pages/RequestsHistory";
 import RequestDetail from "./pages/RequestDetail";
 import { ToastProvider } from "./components/ui/ToastProvider";
+import { bootstrapDemoData } from "./utils/bootstrapDemoData";
+
+// Inicializa datos de demostración en LocalStorage
+// TODO backend: reemplazar con carga desde API al conectar el servidor real
+bootstrapDemoData();
 
 const root = createRoot(document.getElementById("root"));
 root.render(

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,6 +1,20 @@
-const API_BASE = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API)
-  || process.env.REACT_APP_API
-  || 'http://localhost:8000/api';
+// URL base para la API real. Si no está configurada, se utilizarán
+// los datos almacenados en LocalStorage (modo demo).
+const API_BASE =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API) ||
+  process.env.REACT_APP_API ||
+  '';
+
+import { getStorageItem, setStorageItem } from '../utils/storage';
+import {
+  regions as mockRegions,
+  subterritories as mockSubterritories,
+  pdvs as mockPdvs,
+} from '../mock/locationsNormalized';
+import { channels as mockChannels } from '../mock/channels';
+import { materials as mockMaterials } from '../mock/materials';
+import { channelMaterials as mockChannelMaterials } from '../mock/channelMaterials';
+import { campaigns as mockCampaigns } from '../mock/campaigns';
 
 async function http(path, options = {}) {
   const res = await fetch(`${API_BASE}${path}`, {
@@ -14,13 +28,70 @@ async function http(path, options = {}) {
   return res.status === 204 ? null : res.json();
 }
 
+// Helper para obtener/sembrar valores en LocalStorage
+const seed = (key, mock) => {
+  const current = getStorageItem(key);
+  if (current != null) return current;
+  setStorageItem(key, mock);
+  return mock;
+};
+
 // ---------- Catálogos ----------
-export const getRegions = () => http('/regions');
-export const getSubterritories = (regionId) =>
-  regionId ? http(`/subterritories?region_id=${encodeURIComponent(regionId)}`) : http('/subterritories');
-export const getPdvs = (subId) =>
-  subId ? http(`/pdvs?subterritorio_id=${encodeURIComponent(subId)}`) : http('/pdvs');
-export const getChannels = () => http('/channels');
-export const getMaterials = () => http('/materials');
-export const getMaterialsByChannel = (channelId) => http(`/channels/${encodeURIComponent(channelId)}/materials`);
-export const getCampaigns = () => http('/campaigns');
+export const getRegions = () => {
+  if (API_BASE) return http('/regions');
+  // TODO backend: reemplazar por llamada al API real
+  return Promise.resolve(seed('regions', mockRegions));
+};
+
+export const getSubterritories = (regionId) => {
+  if (API_BASE)
+    return regionId
+      ? http(`/subterritories?region_id=${encodeURIComponent(regionId)}`)
+      : http('/subterritories');
+  // TODO backend: reemplazar por llamada al API real
+  const subs = seed('subterritories', mockSubterritories);
+  return Promise.resolve(regionId ? subs[regionId] || [] : Object.values(subs).flat());
+};
+
+export const getPdvs = (subId) => {
+  if (API_BASE)
+    return subId
+      ? http(`/pdvs?subterritorio_id=${encodeURIComponent(subId)}`)
+      : http('/pdvs');
+  // TODO backend: reemplazar por llamada al API real
+  const map = seed('pdvs', mockPdvs);
+  return Promise.resolve(subId ? map[subId] || [] : Object.values(map).flat());
+};
+
+export const getChannels = () => {
+  if (API_BASE) return http('/channels');
+  // TODO backend: reemplazar por llamada al API real
+  return Promise.resolve(seed('channels', mockChannels));
+};
+
+export const getMaterials = () => {
+  if (API_BASE) return http('/materials');
+  // TODO backend: reemplazar por llamada al API real
+  return Promise.resolve(seed('materials', mockMaterials));
+};
+
+export const getMaterialsByChannel = (channelId) => {
+  if (API_BASE)
+    return http(`/channels/${encodeURIComponent(channelId)}/materials`);
+  // TODO backend: reemplazar por llamada al API real
+  const map = seed('channelMaterials', mockChannelMaterials);
+  const mats = seed('materials', mockMaterials);
+  const list = map[channelId] || [];
+  return Promise.resolve(
+    list.map(({ id, stock }) => ({
+      ...mats.find((m) => m.id === id),
+      stock,
+    })),
+  );
+};
+
+export const getCampaigns = () => {
+  if (API_BASE) return http('/campaigns');
+  // TODO backend: reemplazar por llamada al API real
+  return Promise.resolve(seed('campaigns', mockCampaigns));
+};

--- a/src/utils/bootstrapDemoData.js
+++ b/src/utils/bootstrapDemoData.js
@@ -1,0 +1,31 @@
+import { getStorageItem, setStorageItem } from './storage';
+import { channels } from '../mock/channels';
+import { materials } from '../mock/materials';
+import { channelMaterials } from '../mock/channelMaterials';
+import { campaigns } from '../mock/campaigns';
+import { regions, subterritories, pdvs } from '../mock/locationsNormalized';
+
+/**
+ * Carga inicial de datos de demostración en LocalStorage.
+ *
+ * Si las claves correspondientes no existen, se rellenan con los
+ * mocks incluidos en el proyecto. Estos registros sirven como
+ * sustitutos temporales de la base de datos hasta que el backend
+ * real esté disponible.
+ */
+export function bootstrapDemoData() {
+  const seed = (key, value) => {
+    if (getStorageItem(key) == null) {
+      setStorageItem(key, value);
+    }
+  };
+  seed('channels', channels);
+  seed('materials', materials);
+  seed('channelMaterials', channelMaterials);
+  seed('campaigns', campaigns);
+  seed('regions', regions);
+  seed('subterritories', subterritories);
+  seed('pdvs', pdvs);
+}
+
+export default bootstrapDemoData;


### PR DESCRIPTION
- Guardar catálogos ficticios en LocalStorage y cargarlos cuando no haya API.
- Ajustar los servicios y las vistas de los canales para leer los catálogos desde LocalStorage.
- Documentar el uso del modo de demostración.