### PR TITLE
feat(trade): add pdv export by region and channel

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import { getStorageItem, setStorageItem } from './utils/storage';
 import { sanitizeOnBoot } from './utils/cleanupLocalStorage';
 import exportToExcel from './utils/exportToExcel';
 import exportToJson from './utils/exportToJson';
+import exportPdvs from './utils/exportPdvs';
 import { getChannels } from './services/api';
 import { getActiveLocations } from './utils/locationsSource';
 import { useToast } from './components/ui/ToastProvider';
@@ -163,7 +164,14 @@ const App = () => {
   const performExport = (exportObj, options = {}) => {
     const { excel = true, json = false } = options;
     let ok = true;
-    if (excel) ok = exportToExcel(exportObj) && ok;
+    if (excel) {
+      if (exportObj?.meta?.type === 'pdv-list') {
+        // Exportación de PDVs (modo demo)
+        ok = exportPdvs(exportObj) && ok; // TODO backend/export
+      } else {
+        ok = exportToExcel(exportObj) && ok;
+      }
+    }
     if (json) ok = exportToJson(exportObj) && ok;
 
     if (ok) {

--- a/src/components/ExportData.js
+++ b/src/components/ExportData.js
@@ -1,383 +1,255 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { getChannels } from '../services/api';
-import { getActiveLocations } from '../utils/locationsSource';
-import { pdvsForSub } from '../utils/locationSelectors';
-import { getStorageItem } from '../utils/storage';
+import React, { useEffect, useState } from 'react';
+import {
+  fetchRegions,
+  fetchChannels,
+  fetchPdvsByRegionAndChannel,
+} from '../services/tradeNational';
 import StateBlock from './ui/StateBlock';
 
-const getPdvInfo = (pdvId) => {
-  const { regions, subterritories, pdvs } = getActiveLocations();
-  let subId = '';
-  let pdvName = pdvId;
-  Object.entries(pdvs).forEach(([sId, list]) => {
-    const found = list.find((p) => p.id === pdvId);
-    if (found) {
-      subId = sId;
-      pdvName = found.name;
-    }
-  });
-  let regionId = '';
-  Object.entries(subterritories).forEach(([rId, subs]) => {
-    if (subs.find((s) => s.id === subId)) {
-      regionId = rId;
-    }
-  });
-  const regionName = regions.find((r) => r.id === regionId)?.name || regionId;
-  const subName =
-    (subterritories[regionId] || []).find((s) => s.id === subId)?.name || subId;
-  return {
-    id: pdvId,
-    name: pdvName,
-    subterritoryId: subId,
-    subterritoryName: subName,
-    regionId,
-    regionName,
-  };
-};
-
-
+/**
+ * Pantalla de exportación de PDVs para Trade Nacional.
+ *
+ * Permite seleccionar región y canal para listar PDVs, escogerlos
+ * mediante checkboxes y exportar los datos o abrir una selección
+ * personalizada.
+ */
 const ExportData = ({ onBack, onExport }) => {
-  const { regions, subterritories } = getActiveLocations();
+  const [regions, setRegions] = useState([]);
   const [channels, setChannels] = useState([]);
-  const [customMode, setCustomMode] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState('');
-  const [selectedSubterritory, setSelectedSubterritory] = useState('');
-  const [selectedPdv, setSelectedPdv] = useState('');
-  const [summary, setSummary] = useState(null);
-  const [showSummaryModal, setShowSummaryModal] = useState(false);
-  const [showNoDataModal, setShowNoDataModal] = useState(false);
-  const summaryRef = useRef(null);
-  const noDataRef = useRef(null);
-  const lastFocused = useRef(null);
+  const [selectedChannel, setSelectedChannel] = useState('');
+  const [pdvs, setPdvs] = useState([]);
+  const [filteredPdvs, setFilteredPdvs] = useState([]);
+  const [selectedPdvs, setSelectedPdvs] = useState([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [showCustom, setShowCustom] = useState(false);
 
+  // Cargar catálogos
   useEffect(() => {
-    getChannels().then(setChannels).catch(console.error);
+    fetchRegions().then(setRegions).catch(() => setError(true));
+    fetchChannels().then(setChannels).catch(() => setError(true));
   }, []);
 
+  // Obtener PDVs al cambiar filtros
   useEffect(() => {
-    if (showSummaryModal && summaryRef.current) {
-      lastFocused.current = document.activeElement;
-      summaryRef.current.focus();
+    if (!selectedRegion) {
+      setPdvs([]);
+      setSelectedPdvs([]);
+      return;
     }
-  }, [showSummaryModal]);
+    setLoading(true);
+    fetchPdvsByRegionAndChannel(selectedRegion, selectedChannel)
+      .then((list) => {
+        setPdvs(list);
+        setSelectedPdvs([]);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError(true);
+        setLoading(false);
+      });
+  }, [selectedRegion, selectedChannel]);
 
+  // Filtrado por texto
   useEffect(() => {
-    if (showNoDataModal && noDataRef.current) {
-      lastFocused.current = document.activeElement;
-      noDataRef.current.focus();
-    }
-  }, [showNoDataModal]);
+    const term = search.toLowerCase();
+    setFilteredPdvs(
+      pdvs.filter(
+        (p) =>
+          p.name.toLowerCase().includes(term) ||
+          p.id.toLowerCase().includes(term),
+      ),
+    );
+  }, [search, pdvs]);
 
-
-  const buildExportObject = (requests, scope) => {
-    return {
-      scope,
-      pdvs: requests.map((req) => {
-        const info = getPdvInfo(req.pdvId);
-        return {
-          ...info,
-          regionName: req.region || info.regionName,
-          subterritoryName: req.subterritory || info.subterritoryName,
-          channelId: req.channelId,
-          channelName:
-            channels.find((c) => c.id === req.channelId)?.name || req.channelId,
-          date: req.date || new Date().toISOString(),
-          requestType: 'Solicitud',
-          zone: req.zones || [],
-          priority: req.priority || '',
-          campaigns: req.campaigns || [],
-          pdvData:
-            req.pdvSnapshot ||
-            req.pdvData ||
-            getStorageItem(`pdv-${req.pdvId}-data`) || {},
-          materials: (req.items || []).map((it) => ({
-            id: it.material.id,
-            name: it.material.name,
-            quantity: it.quantity,
-            measure: it.measures.name,
-            requiresCotizacion: it.material.requiresCotizacion,
-            observations: it.notes || '',
-          })),
-        };
-      }),
-    };
+  const togglePdv = (id) => {
+    setSelectedPdvs((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+    );
   };
 
-  const handleExportChannel = (channelId) => {
-    const allRequests = getStorageItem('material-requests') || [];
-    const channelRequests = allRequests.filter((r) => r.channelId === channelId);
+  const handleSelectAll = () => setSelectedPdvs(pdvs.map((p) => p.id));
+  const handleClearSelection = () => setSelectedPdvs([]);
+
+  const handleExport = () => {
+    const regionName = regions.find((r) => r.id === selectedRegion)?.name || '';
     const channelName =
-      channels.find((c) => c.id === channelId)?.name || channelId;
-    if (channelRequests.length === 0) {
-      setShowNoDataModal(true);
-      return;
-    }
-    const exportObj = buildExportObject(channelRequests, `Canal-${channelName}`);
+      channels.find((c) => c.id === selectedChannel)?.name || '';
+    const list = pdvs.filter((p) => selectedPdvs.includes(p.id));
+    const exportObj = {
+      regionName,
+      channelName,
+      pdvs: list,
+      meta: { type: 'pdv-list' },
+    };
     onExport(exportObj, { excel: true });
-  };
-
-  const collectPdvIds = () => {
-    if (!selectedRegion) return [];
-    if (selectedPdv) return [selectedPdv];
-    if (selectedSubterritory) {
-      return pdvsForSub(selectedSubterritory)
-        .filter((p) => p.complete)
-        .map((p) => p.id);
-    }
-    let ids = [];
-    (subterritories[selectedRegion] || []).forEach((sub) => {
-      ids = ids.concat(
-        pdvsForSub(sub.id)
-          .filter((p) => p.complete)
-          .map((p) => p.id),
-      );
-    });
-    return ids;
-  };
-
-  const buildFilteredRequests = () => {
-    const allRequests = getStorageItem('material-requests') || [];
-    const pdvIds = collectPdvIds();
-    return allRequests.filter((r) => pdvIds.includes(r.pdvId));
-  };
-
-  const getScopeLabel = () => {
-    if (selectedPdv) {
-      const pdvName =
-        pdvsForSub(selectedSubterritory).find((p) => p.id === selectedPdv)?.name ||
-        selectedPdv;
-      return `PDV-${pdvName}`;
-    }
-    if (selectedSubterritory) {
-      const subName =
-        (subterritories[selectedRegion] || []).find((s) => s.id === selectedSubterritory)?.name ||
-        selectedSubterritory;
-      return `Subterritorio-${subName}`;
-    }
-    const regionName = regions.find((r) => r.id === selectedRegion)?.name || selectedRegion;
-    return `Region-${regionName}`;
-  };
-
-  const handleGenerateSummary = () => {
-    const filtered = buildFilteredRequests();
-    if (filtered.length === 0) {
-      setShowNoDataModal(true);
-      return;
-    }
-    const exportObj = buildExportObject(filtered, getScopeLabel());
-    const totalItems = filtered.reduce((sum, r) => sum + (r.items ? r.items.length : 0), 0);
-    setSummary({ ...exportObj, totalItems });
-    setShowSummaryModal(true);
-  };
-
-  const handleConfirmExport = () => {
-    if (summary) {
-      onExport(summary, { excel: true });
-    }
-    setShowSummaryModal(false);
-    setSummary(null);
-    lastFocused.current && lastFocused.current.focus();
-  };
-
-  const closeSummary = () => {
-    setShowSummaryModal(false);
-    setSummary(null);
-    lastFocused.current && lastFocused.current.focus();
-  };
-
-  const closeNoData = () => {
-    setShowNoDataModal(false);
-    lastFocused.current && lastFocused.current.focus();
   };
 
   return (
     <div className="p-6 bg-white rounded-xl shadow-lg max-w-xl mx-auto">
       <h2 className="text-2xl font-semibold text-gray-800 mb-4 text-center">
-        Exporte de datos para los siguientes canales
+        PDVs por Región y Canal
       </h2>
-      {!customMode ? (
-        <>
-          <div className="space-y-2 mb-4">
-            {channels.map((ch) => (
-              <button
-                key={ch.id}
-                onClick={() => handleExportChannel(ch.id)}
-                className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
-              >
-                {ch.name}
-              </button>
-            ))}
-            <button
-              onClick={() => setCustomMode(true)}
-              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
-            >
-              PERSONALIZADO
-            </button>
-          </div>
-          <button
-            onClick={onBack}
-            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
-          >
-            Volver al Inicio
-          </button>
-        </>
-      ) : (
-        <>
-          <div className="space-y-4 mb-4">
-            <div>
-              <label className="block text-gray-700 text-sm font-bold mb-2">Región:</label>
-              <select
-                value={selectedRegion}
-                onChange={(e) => {
-                  setSelectedRegion(e.target.value);
-                  setSelectedSubterritory('');
-                  setSelectedPdv('');
-                  setSummary(null);
-                }}
-                className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
-              >
-                <option value="">Selecciona una región</option>
-                {regions.map((r) => (
-                  <option key={r.id} value={r.id}>
-                    {r.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-            {selectedRegion && (
-              <div>
-                <label className="block text-gray-700 text-sm font-bold mb-2">Subterritorio:</label>
-                <select
-                  value={selectedSubterritory}
-                  onChange={(e) => {
-                    setSelectedSubterritory(e.target.value);
-                    setSelectedPdv('');
-                    setSummary(null);
-                  }}
-                  className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
-                >
-                  <option value="">Todos</option>
-                  {(subterritories[selectedRegion] || []).map((s) => (
-                    <option key={s.id} value={s.id}>
-                      {s.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-            {selectedSubterritory && (
-              <div>
-                <label className="block text-gray-700 text-sm font-bold mb-2">PDV:</label>
-                <select
-                  value={selectedPdv}
-                  onChange={(e) => {
-                    setSelectedPdv(e.target.value);
-                    setSummary(null);
-                  }}
-                  className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
-                >
-                  <option value="">Todos</option>
-                  {pdvsForSub(selectedSubterritory)
-                    .filter((p) => p.complete)
-                    .map((p) => (
-                      <option key={p.id} value={p.id}>
-                        {p.name}
-                      </option>
-                    ))}
-                </select>
-              </div>
-            )}
-          </div>
-          <div className="mb-4">
-            <button
-              onClick={handleGenerateSummary}
-              disabled={!selectedRegion}
-              className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-tigo-blue"
-            >
-              Mostrar resumen
-            </button>
-          </div>
-          {/* El resumen y exportación se manejan mediante un modal */}
-          <button
-            onClick={() => {
-              setCustomMode(false);
-              setSelectedRegion('');
-              setSelectedSubterritory('');
-              setSelectedPdv('');
-              setSummary(null);
+      <div className="space-y-4 mb-4">
+        <div>
+          <label className="block text-gray-700 text-sm font-bold mb-2">
+            Región:
+          </label>
+          <select
+            value={selectedRegion}
+            onChange={(e) => {
+              setSelectedRegion(e.target.value);
+              setSelectedChannel('');
+              setSearch('');
             }}
-            className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all focus:outline-none focus:ring-2 focus:ring-tigo-blue"
+            className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
           >
-            Volver al Inicio
-          </button>
-        </>
-      )}
-      {showSummaryModal && summary && (
+            <option value="">Selecciona una región</option>
+            {regions.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-gray-700 text-sm font-bold mb-2">
+            Canal:
+          </label>
+          <select
+            value={selectedChannel}
+            onChange={(e) => {
+              setSelectedChannel(e.target.value);
+            }}
+            className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg"
+          >
+            <option value="">Todos</option>
+            {channels.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        {selectedRegion && (
+          <div>
+            <label className="block text-gray-700 text-sm font-bold mb-2">
+              Buscar PDV:
+            </label>
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Ingresa nombre o código"
+              className="block w-full bg-gray-100 border border-gray-300 text-gray-900 py-2 px-3 rounded-lg mb-2"
+            />
+            <div className="border border-gray-200 rounded max-h-60 overflow-y-auto">
+              {loading && <StateBlock variant="loading" title="Cargando..." />}
+              {!loading && filteredPdvs.length === 0 && (
+                <StateBlock variant="empty" title="No hay PDVs" />
+              )}
+              {!loading &&
+                filteredPdvs.map((p) => (
+                  <label
+                    key={p.id}
+                    className="flex items-center space-x-2 px-2 py-1 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedPdvs.includes(p.id)}
+                      onChange={() => togglePdv(p.id)}
+                    />
+                    <span>{p.name}</span>
+                  </label>
+                ))}
+            </div>
+            {pdvs.length > 0 && (
+              <div className="flex justify-between items-center mt-2">
+                <span className="text-sm text-gray-600">
+                  {`${selectedPdvs.length} PDVs seleccionados de ${pdvs.length}`}
+                </span>
+                <div className="space-x-2">
+                  <button
+                    onClick={handleSelectAll}
+                    className="text-sm text-tigo-blue"
+                  >
+                    Seleccionar todo
+                  </button>
+                  <button
+                    onClick={handleClearSelection}
+                    className="text-sm text-tigo-blue"
+                  >
+                    Limpiar selección
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="space-y-2">
+        <button
+          onClick={handleExport}
+          disabled={selectedPdvs.length === 0}
+          className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all disabled:opacity-50"
+        >
+          Exportar datos
+        </button>
+        <button
+          onClick={() => setShowCustom(true)}
+          disabled={selectedPdvs.length === 0}
+          className="w-full bg-gray-600 text-white py-2 px-4 rounded-lg shadow-md hover:bg-gray-700 transition-all disabled:opacity-50"
+        >
+          Personalizado
+        </button>
+        <button
+          onClick={onBack}
+          className="w-full bg-tigo-blue text-white py-3 px-4 rounded-lg shadow-md hover:bg-[#00447e] transition-all"
+        >
+          Volver al Inicio
+        </button>
+      </div>
+      {showCustom && (
         <div
           className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
           role="dialog"
           aria-modal="true"
-          aria-labelledby="summary-title"
-          onKeyDown={(e) => e.key === 'Escape' && closeSummary()}
         >
-          <div
-            ref={summaryRef}
-            tabIndex="-1"
-            className="bg-white p-6 rounded-xl max-w-sm w-full max-h-[80vh] overflow-y-auto"
-          >
-            <h3 id="summary-title" className="text-lg font-semibold mb-2">Resumen de exportación</h3>
-            <div className="text-sm mb-4 space-y-1">
-              <p>Región: {regions.find((r) => r.id === selectedRegion)?.name}</p>
-              {selectedSubterritory && (
-                <p>
-                  Subterritorio:{' '}
-                  {(subterritories[selectedRegion] || []).find((s) => s.id === selectedSubterritory)?.name}
-                </p>
-              )}
-              {selectedPdv && (
-                <p>
-                  PDV:{' '}
-                    {pdvsForSub(selectedSubterritory).find((p) => p.id === selectedPdv)?.name}
-                </p>
-              )}
-              <p>PDVs: {summary.pdvs.length}</p>
-              <p>Ítems: {summary.totalItems}</p>
+          <div className="bg-white p-6 rounded-xl max-w-sm w-full">
+            <h3 className="text-lg font-semibold mb-4">
+              Selección personalizada
+            </h3>
+            <div className="max-h-60 overflow-y-auto mb-4 border border-gray-200 rounded">
+              {pdvs.map((p) => (
+                <label
+                  key={p.id}
+                  className="flex items-center space-x-2 px-2 py-1 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedPdvs.includes(p.id)}
+                    onChange={() => togglePdv(p.id)}
+                  />
+                  <span>{p.name}</span>
+                </label>
+              ))}
             </div>
             <div className="flex justify-end space-x-2">
               <button
-                onClick={closeSummary}
-                className="px-4 py-2 bg-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-tigo-blue"
+                onClick={() => setShowCustom(false)}
+                className="px-4 py-2 bg-gray-300 rounded"
               >
-                Revisar otra vez
+                Cancelar
               </button>
               <button
-                onClick={handleConfirmExport}
-                className="px-4 py-2 bg-green-500 text-white rounded focus:outline-none focus:ring-2 focus:ring-tigo-blue"
+                onClick={() => setShowCustom(false)}
+                className="px-4 py-2 bg-green-500 text-white rounded"
               >
-                Exportar
+                Confirmar
               </button>
             </div>
-          </div>
-        </div>
-      )}
-      {showNoDataModal && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
-          role="dialog"
-          aria-modal="true"
-          onKeyDown={(e) => e.key === 'Escape' && closeNoData()}
-        >
-          <div
-            ref={noDataRef}
-            tabIndex="-1"
-            className="bg-white p-6 rounded-xl max-w-sm w-full max-h-[80vh] overflow-y-auto"
-          >
-            <StateBlock
-              variant="empty"
-              title="No hay datos para exportar. Revisa tu selección y filtros."
-              actionLabel="Revisar otra vez"
-              onAction={closeNoData}
-            />
           </div>
         </div>
       )}
@@ -386,3 +258,4 @@ const ExportData = ({ onBack, onExport }) => {
 };
 
 export default ExportData;
+

--- a/src/services/tradeNational.js
+++ b/src/services/tradeNational.js
@@ -1,0 +1,56 @@
+import { getRegions, getChannels, getSubterritories, getPdvs } from './api';
+
+// Regiones válidas para Trade Nacional
+const VALID_REGIONS = ['Sur', 'Andina', 'Bogota', 'Costa'];
+
+/**
+ * Obtiene las regiones disponibles.
+ *
+ * En modo demo utiliza LocalStorage. Si se configura API_BASE
+ * en los servicios generales, reutiliza esa fuente de datos.
+ */
+export async function fetchRegions() {
+  const regions = await getRegions();
+  // Filtrar solo las regiones válidas
+  return regions.filter((r) => VALID_REGIONS.includes(r.name));
+}
+
+/**
+ * Obtiene los canales disponibles.
+ */
+export function fetchChannels() {
+  return getChannels();
+}
+
+/**
+ * Devuelve los PDVs para una región y canal determinados.
+ *
+ * @param {string} regionId
+ * @param {string} [channelId]
+ * @returns {Promise<Array>} Lista de PDVs completos
+ */
+export async function fetchPdvsByRegionAndChannel(regionId, channelId) {
+  if (!regionId) return [];
+  // Obtener subterritorios de la región
+  const subs = await getSubterritories(regionId);
+  const subMap = Object.fromEntries(subs.map((s) => [s.id, s.name]));
+  // Obtener PDVs de todos los subterritorios
+  const pdvLists = await Promise.all(subs.map((s) => getPdvs(s.id)));
+  let allPdvs = pdvLists
+    .flat()
+    .filter((p) => p.complete)
+    .map((p) => ({ ...p, subterritoryName: subMap[p.subterritoryId] || '' }));
+
+  // TODO backend: filtrar PDVs por canal cuando el modelo lo soporte
+  if (channelId) {
+    // Actualmente no hay relación PDV-canal en el modo demo
+  }
+
+  return allPdvs;
+}
+
+export default {
+  fetchRegions,
+  fetchChannels,
+  fetchPdvsByRegionAndChannel,
+};

--- a/src/utils/exportPdvs.js
+++ b/src/utils/exportPdvs.js
@@ -1,0 +1,49 @@
+import * as XLSX from 'xlsx';
+
+/**
+ * Exporta un listado de PDVs a un archivo Excel.
+ *
+ * @param {Object} data
+ * @param {string} data.regionName
+ * @param {string} data.channelName
+ * @param {Array} data.pdvs
+ * @returns {boolean} true si se generó el archivo
+ */
+export default function exportPdvs(data = {}) {
+  try {
+    const { regionName = '', channelName = '', pdvs = [] } = data;
+    const workbook = XLSX.utils.book_new();
+
+    // Hoja 1: resumen
+    const summary = [
+      {
+        region: regionName,
+        channel: channelName,
+        date: new Date().toISOString(),
+        totalPdvs: pdvs.length,
+      },
+    ];
+    const wsSummary = XLSX.utils.json_to_sheet(summary);
+    XLSX.utils.book_append_sheet(workbook, wsSummary, 'Resumen');
+
+    // Hoja 2: detalle de PDVs
+    const pdvRows = pdvs.map((p) => ({
+      id: p.id,
+      nombre: p.name,
+      subterritorio: p.subterritoryName || '',
+      region: p.regionName || regionName,
+      canal: channelName,
+    }));
+    const wsPdvs = XLSX.utils.json_to_sheet(pdvRows);
+    XLSX.utils.book_append_sheet(workbook, wsPdvs, 'PDVs');
+
+    const date = new Date().toISOString().split('T')[0];
+    const filename = `Export_PDVs_${date}.xlsx`;
+    // TODO backend/export: reemplazar por exportación desde backend si aplica
+    XLSX.writeFile(workbook, filename);
+    return true;
+  } catch (e) {
+    console.error('Error exporting PDVs', e);
+    return false;
+  }
+}


### PR DESCRIPTION
- Añadir asistentes de servicio comercial para búsquedas por regiones, canales y puntos de venta.
- Exportar listas de puntos de venta a Excel con metadatos resumidos.
- Mostrar puntos de venta filtrados por región y canal con una lista seleccionable y un modal personalizado.